### PR TITLE
Add CLDERA developer test suite

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -457,4 +457,11 @@ _TESTS = {
             )
     },
 
+    "e3sm_cldera" : {
+        "tests" : (
+            "ERS_Ln9.ne4pg2_oQU480.F20TR.eam-prognostic_volcaero",
+            "SMS_D_Ln9.ne4pg2_ne4pg2.F20TR-CICE.eam-prognostic_volcaero",
+            )
+    },
+
 }

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/prognostic_volcaero/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/prognostic_volcaero/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange RUN_STARTDATE="1991-01-01"

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/prognostic_volcaero/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/prognostic_volcaero/user_nl_eam
@@ -1,0 +1,18 @@
+ext_frc_specifier    = 
+        'SO2         -> /sems-data-store/ACME/cldera/data/E3SM/model_input/emissions/volc/merge_cmip6_and_volc_so2/merged_cmip6_and_volc_so2.nc',
+        'SOAG        -> $DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1850-2014_c180205.nc',
+        'bc_a4       -> $DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c180205.nc',
+        'num_a1      -> $DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c180205.nc',
+        'num_a2      -> $DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c180205.nc',
+        'num_a4      -> $DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c180205.nc',
+        'pom_a4      -> $DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc',
+        'so4_a1      -> $DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc',
+        'so4_a2      -> $DIN_LOC_ROOT/atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc'
+
+prescribed_volcaero_filetype = 'VOLC_MIXING_RATIO'
+prescribed_volcaero_datapath = '/sems-data-store/ACME/cldera/data/E3SM/model_input/emissions/volc/zero-presc-volc-mmr/'
+prescribed_volcaero_file = 'BMW_volcanic_1850-3009_all_zero.nc'
+
+use_hetfrz_classnuc  = .true.
+hist_hetfrz_classnuc = .true.
+


### PR DESCRIPTION
Add CLDERA developer test suite, consisting of two new tests:
```
ERS_Ln9.ne4pg2_oQU480.F20TR.eam-prognostic_volcaero
SMS_D_Ln9.ne4pg2_ne4pg2.F20TR-CICE.eam-prognostic_volcaero
```
Both of these tests use the prognostic volcanic aerosol in 20th century transient configurations @wagmanbe and @hbrown18 are working with. A new testmod is added to support the prognostic volcanic aerosol configuration (`eam-prognostic_volcaero`). Two tests are added to cover the new v2 default of using MPASI for sea ice instead of CICE, as well as the old CICE configuration for backwards compatibility with ongoing simulations that use resolutions that look like `ne4pg2_ne4pg2`.