### PR TITLE
Fix cldera-tools requirement

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -487,6 +487,7 @@ _TESTS = {
     "e3sm_cldera" : {
         "tests" : (
             "ERS_Ln9.ne4pg2_oQU480.F20TR.eam-prognostic_volcaero",
+            "ERS_Ln9.ne4pg2_oQU480.F20TR-CLDERA.eam-prognostic_volcaero",
             "SMS_D_Ln9.ne4pg2_ne4pg2.F20TR-CICE.eam-prognostic_volcaero",
             )
     },

--- a/components/cmake/common_setup.cmake
+++ b/components/cmake/common_setup.cmake
@@ -54,8 +54,11 @@ if (${USE_YAKL})
 endif()
 
 # Detect if CLDERA profiling tool lib has to be used
-string(FIND "${CAM_CONFIG_OPTS}" "-cldera_profiling" USE_CLDERA_PROFILING)
-
+string(FIND "${CAM_CONFIG_OPTS}" "-cldera_profiling" HAS_CLDERA_PROFILING)
+if (NOT HAS_CLDERA_PROFILING EQUAL -1)
+  # The following is for cldera profiling code:
+  set(USE_CLDERA_PROFILING TRUE)
+endif()
 
 #===============================================================================
 # set CPP options (must use this before any flags or cflags settings)

--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -48,7 +48,7 @@
 
       <value compset=""                >-mach $MACH</value>
       <value compset="_EAM"            >-phys default</value>
-      <value compset="_EAM%CMIP6_"     >&eam_phys_defaults; &eam_chem_defaults;</value>
+      <value compset="_EAM%CMIP6"      >&eam_phys_defaults; &eam_chem_defaults;</value>
       <value compset="_EAM%AR5sf"      >&eam_phys_defaults; -chem superfast_mam4_resus_mom_soag -rain_evap_to_coarse_aero</value>
       <value compset="_ELM%[^_]*BC"    >-bc_dep_to_snow_updates</value>
       <value compset="_EAM.*_BGC%*"    >-co2_cycle</value>

--- a/components/eam/src/cpl/atm_comp_mct.F90
+++ b/components/eam/src/cpl/atm_comp_mct.F90
@@ -667,7 +667,9 @@ CONTAINS
     endif
 #endif
 
+#if defined(CLDERA_PROFILING)
     call cldera_compute_stats(ymd,tod)
+#endif
 
   end subroutine atm_run_mct
 


### PR DESCRIPTION
This should fix the cldera-tools requirement (#10). I verified that the original two tests are not using cldera-tools and the new test is using cldera-tools on mappy.

It should be easy to rebase this if we want to merge upstream master first.