### PR TITLE
Add CLDERA_PATH to gnu_mappy.cmake mach file

### DIFF
--- a/cime_config/machines/cmake_macros/gnu_mappy.cmake
+++ b/cime_config/machines/cmake_macros/gnu_mappy.cmake
@@ -1,4 +1,5 @@
 set(ALBANY_PATH "/projects/install/rhel7-x86_64/ACME/AlbanyTrilinos/Albany/build/install")
+set(CLDERA_PATH "/sems-data-store/ACME/cldera/cldera-tools/install")
 if (COMP_NAME STREQUAL gptl)
   string(APPEND CPPDEFS " -DHAVE_SLASHPROC")
 endif()


### PR DESCRIPTION
Restoring a commit that got lost while changing cldera-e3sm/master to be based off e3sm-project/maint-2.0