### PR TITLE
Fix namelist defaults for compatibility with FIDEAL

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -494,6 +494,7 @@ _TESTS = {
             "ERS_Ln9.ne4pg2_oQU480.F20TR.eam-prognostic_volcaero",
             "ERS_Ln9.ne4pg2_oQU480.F20TR-CLDERA.eam-prognostic_volcaero",
             "SMS_D_Ln9.ne4pg2_ne4pg2.F20TR-CICE.eam-prognostic_volcaero",
+            "SMS.ne4_ne4.FIDEAL",
             )
     },
 

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -152,6 +152,7 @@
 <bnd_topo hgrid="ne0np4_twpx4v1" >atm/cam/topo/USGS_twpx4v1_tensor12x_consistentSGH_170629.nc</bnd_topo>
 
 <!-- ieflx_opt 0: atmonly, 3: coupled -->
+<ieflx_opt  ocn="socn" >0</ieflx_opt>
 <ieflx_opt  ocn="docn" >0</ieflx_opt>
 <ieflx_opt  ocn="mpaso" >3</ieflx_opt>
 
@@ -1627,10 +1628,10 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <!-- Ice nucleation mods-->
 <use_hetfrz_classnuc phys="default">.true.</use_hetfrz_classnuc>
 <use_hetfrz_classnuc MMF_microphysics_scheme="sam1mom">.false.</use_hetfrz_classnuc>
-<use_preexisting_ice phys="default">.false.</use_preexisting_ice>
-<hist_hetfrz_classnuc phys="default">.false.</hist_hetfrz_classnuc>
+<use_preexisting_ice               >.false.</use_preexisting_ice>
+<hist_hetfrz_classnuc              >.false.</hist_hetfrz_classnuc>
 <micro_mg_dcs_tdep phys="default">.true.</micro_mg_dcs_tdep>
-<microp_aero_wsub_scheme phys="default">1</microp_aero_wsub_scheme>
+<microp_aero_wsub_scheme               >1</microp_aero_wsub_scheme>
 
 <!-- For Polar mods-->
 <sscav_tuning phys="default">.true.</sscav_tuning>
@@ -1678,13 +1679,13 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <zmconv_trigdcape_ull phys="default"> .true.     </zmconv_trigdcape_ull>
 <cld_sed phys="default" microphys="mg2"> 1.0D0      </cld_sed>
 <effgw_beres phys="default"> 0.35       </effgw_beres>
-<gw_convect_hcf phys="default"> 10.0       </gw_convect_hcf>
+<gw_convect_hcf            > 10.0       </gw_convect_hcf>
 <effgw_oro phys="default"> 0.375      </effgw_oro>
 <use_gw_energy_fix phys="default"> .true.      </use_gw_energy_fix>
 <clubb_C14 phys="default"> 2.5D0      </clubb_C14>
 <clubb_tk1 phys="default"> 268.15D0   </clubb_tk1>
 <dust_emis_fact phys="default"> 1.50D0     </dust_emis_fact>
-<linoz_psc_T phys="default"> 197.5      </linoz_psc_T>
+<linoz_psc_T               > 197.5      </linoz_psc_T>
 <micro_mincdnc phys="default" microphys="mg2"> 10.D6      </micro_mincdnc>
 <clubb_C1 phys="default"> 2.4        </clubb_C1>
 <clubb_C11 phys="default"> 0.70       </clubb_C11>
@@ -1714,7 +1715,7 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <zmconv_mx_bot_lyr_adj phys="default"> 1          </zmconv_mx_bot_lyr_adj>
 <prc_exp1 phys="default"  microphys="mg2"> -1.40D0    </prc_exp1>
 <micro_mg_accre_enhan_fac phys="default" microphys="mg2"> 1.75D0     </micro_mg_accre_enhan_fac>
-<microp_aero_wsubmin phys="default"> 0.001D0    </microp_aero_wsubmin>
+<microp_aero_wsubmin               > 0.001D0    </microp_aero_wsubmin>
 <so4_sz_thresh_icenuc phys="default"> 0.080e-6   </so4_sz_thresh_icenuc>
 <micro_mg_berg_eff_factor phys="default" clubb_sgs="1"> 0.7D0      </micro_mg_berg_eff_factor>
 <cldfrc_dp1  phys="default"> 0.018D0    </cldfrc_dp1>


### PR DESCRIPTION
Fix EAM namelist default settings for compatibility with FIDEAL. This apparently was missed when porting the FIDEAL changes from E3SM/master to CLDERA-E3SM/master, so this compset would fail to configure on CLDERA-E3SM/master after we setup CLDERA-E3SM/master to track E3SM/maint-2.0. This also adds a test for FIDEAL to the e3sm_cldera test suite. This PR is BFB, other than the addition of the new test that will need baselines created for.

[BFB]