### PR TITLE
hbrown18/atm/prognostic_volcanic_aerosol

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -492,6 +492,7 @@ _TESTS = {
     "e3sm_cldera" : {
         "tests" : (
             "ERS_Ln9.ne4pg2_oQU480.F20TR.eam-prognostic_volcaero",
+            "ERS_Ln9.ne4pg2_oQU480.F20TR.eam-cldera_strat_volc",
             "ERS_Ln9.ne4pg2_oQU480.F20TR-CLDERA.eam-prognostic_volcaero",
             "SMS_D_Ln9.ne4pg2_ne4pg2.F20TR-CICE.eam-prognostic_volcaero",
             "SMS.ne4_ne4.FIDEAL",

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -737,7 +737,7 @@ if ($rad_volcaero){
     }
 }
 
-# hybrown, Adding call for CLDERA prognostic stratospheric volcanic aerosol treatment
+# Adding call for CLDERA prognostic stratospheric volcanic aerosol treatment
 my $cldera_strat_volc = $cfg->get('cldera_strat_volc'); #default should be no CLDERA treatment (0)
 
 #################

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -737,6 +737,9 @@ if ($rad_volcaero){
     }
 }
 
+# hybrown, Adding call for CLDERA prognostic stratospheric volcanic aerosol treatment
+my $cldera_strat_volc = $cfg->get('cldera_strat_volc'); #default should be no CLDERA treatment (0)
+
 #################
 # CAM namelists #
 #################
@@ -1111,7 +1114,7 @@ if ($prescribed_aero_model eq 'modal' or $chem =~ /_mam/) {
 if ($aer_model eq 'mam' ) {
 
   #hybrown - setting namelist flag for stratospheric aerosol renaming in mam
-  add_default($nl,'strat_accum_coarse_rename');
+  #add_default($nl,'cldera_prog');
 
   my $aero_modes = '3mode';
   if ($chem =~ /_mam4/) {$aero_modes = '4mode';}

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -1113,9 +1113,6 @@ if ($prescribed_aero_model eq 'modal' or $chem =~ /_mam/) {
 
 if ($aer_model eq 'mam' ) {
 
-  #hybrown - setting namelist flag for stratospheric aerosol renaming in mam
-  #add_default($nl,'cldera_prog');
-
   my $aero_modes = '3mode';
   if ($chem =~ /_mam4/) {$aero_modes = '4mode';}
   if ($chem =~ /_mam4_mom/) {$aero_modes = '4mode_mom';}

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -1110,6 +1110,9 @@ if ($prescribed_aero_model eq 'modal' or $chem =~ /_mam/) {
 
 if ($aer_model eq 'mam' ) {
 
+  #hybrown - setting namelist flag for stratospheric aerosol renaming in mam
+  add_default($nl,'strat_accum_coarse_rename');
+
   my $aero_modes = '3mode';
   if ($chem =~ /_mam4/) {$aero_modes = '4mode';}
   if ($chem =~ /_mam4_mom/) {$aero_modes = '4mode_mom';}

--- a/components/eam/bld/config_files/definition.xml
+++ b/components/eam/bld/config_files/definition.xml
@@ -368,4 +368,8 @@ CRM number of averaged columns in x for radiation
 CRM number of averaged columns in y for radiation
 </entry>
 
+<entry id="cldera_strat_volc" valid_values="0,1" value="0">
+Switch to enable prognostic volcanic aerosol treatment in stratosphere in MAM4 simulations: 0=off, 1=on.
+</entry>
+
 </config_definition>

--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -335,9 +335,7 @@ GetOptions(
     "ccsm_seq"                  => \$opts{'ccsm_seq'},
     "cflags=s"                  => \$opts{'cflags'},
     "chem=s"                    => \$opts{'chem'},
-#++hybrown
     "cldera_strat_volc=s"         => \$opts{'cldera_strat_volc'},
-#--hybrown
     "cice_bsizex=s"             => \$opts{'cice_bsizex'},
     "cice_bsizey=s"             => \$opts{'cice_bsizey'},
     "cice_maxblocks=s"          => \$opts{'cice_maxblocks'},
@@ -1389,7 +1387,7 @@ if (($chem_pkg ne 'none') || ($prog_species)) {
 if ($chem_pkg =~ '_mam3') {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_3MODE ';
 } elsif ($chem_pkg =~ '_mam4_mom' || $chem_pkg =~ '_mam4_resus_mom' ) {
-#++hybrown, for turning on CLDERA stratospheric volcanic aerosol treatment
+#for turning on CLDERA stratospheric volcanic aerosol treatment
 #    $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE_MOM ';
     if (!defined $opts{'cldera_strat_volc'} ) {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE_MOM ';
@@ -1409,7 +1407,6 @@ if ($chem_pkg =~ '_mam3') {
         $cfg_ref->set('cldera_strat_volc', $cldera_strat_volc);
     $chem_cppdefs = " -DMODAL_AERO -DMODAL_AERO_4MODE -DCLDERA_STRAT_VOLC=$cldera_strat_volc";
     }
-#--hybrown
 } elsif ($chem_pkg =~ '_mam4' ) {
 } elsif ($chem_pkg =~ '_mam7') {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_7MODE ';

--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -1382,20 +1382,9 @@ if (($chem_pkg ne 'none') || ($prog_species)) {
 if ($chem_pkg =~ '_mam3') {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_3MODE ';
 } elsif ($chem_pkg =~ '_mam4_mom' || $chem_pkg =~ '_mam4_resus_mom' ) {
-#    if ($cldera_strat_volc == 1) {
-#        print "cldera_strat_volc: $cldera_strat_volc"
-#        $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE_MOM -DCLDERA_STRAT_VOLC ';
-#    } else {
-#        print "cldera_strat_volc: $cldera_strat_volc"
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE_MOM ';
-#    }   
-
 } elsif ($chem_pkg =~ '_mam4' ) {
-#    if ($cldera_strat_volc == 1) {
-#        $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE -DCLDERA_STRAT_VOLC ';
-#    } else {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE ';
-#    }
 } elsif ($chem_pkg =~ '_mam4' ) {
 } elsif ($chem_pkg =~ '_mam7') {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_7MODE ';

--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -112,6 +112,7 @@ OPTIONS
   effect whether running EAM as part of CCSM or running in a EAM standalone mode:
 
      -[no]age_of_air_trcs Switch on [off] age of air tracers. Default: on for waccm_phys, otherwise off
+     -cldera_sai_trcs   Switch on idealized stratospheric aerosol injection tracers. Default: off
      -aquaplanet        Switch on aqua-planet mode w/ SST controlled by data ocean component in CIME
      -rce               Use homogenous conditions for radiative-convective equilibrium (RCE), normally used with aquaplanet
      -chem <name>       Build EAM with specified prognostic chemistry package
@@ -280,6 +281,9 @@ OPTIONS
      -crm_adv           CRM advection scheme [MPDATA | UM5]
      -crm <model>       CRM model [sam | samomp | samxx]
      -rrtmgpxx          Use RRTMGP++ code
+
+  Options for CLDERA-E3SM
+     -cldera_profiling  Build EAM with support for CLDERA profiling, linking to cldera-profiling
 EOF
 }
 
@@ -317,6 +321,7 @@ my %opts = (
 	    );
 GetOptions(
     "age_of_air_trcs!"          => \$opts{'age_of_air_trcs'},
+    "cldera_sai_trcs!"          => \$opts{'cldera_sai_trcs'},
     "aquaplanet"                => \$opts{'aquaplanet'},
     "cache=s"                   => \$opts{'cache'},
     "cachedir=s"                => \$opts{'cachedir'},
@@ -354,6 +359,7 @@ GetOptions(
     "crm_adv=s"                 => \$opts{'crm_adv'},
     "crm=s"                     => \$opts{'crm'},
     "rrtmgpxx"                  => \$opts{'rrtmgpxx'},
+    "cldera_profiling"          => \$opts{'cldera_profiling'},
     "debug"                     => \$opts{'debug'},
     "rain_evap_to_coarse_aero"  => \$opts{'rain_evap_to_coarse_aero'},
     "bc_dep_to_snow_updates"    => \$opts{'bc_dep_to_snow_updates'},
@@ -864,8 +870,14 @@ if (defined $opts{'age_of_air_trcs'}) {
     $cfg_ref->set('age_of_air_trcs', $opts{'age_of_air_trcs'});
 }
 my $age_of_air_trcs = $cfg_ref->get('age_of_air_trcs') ? "ON" : "OFF";
-
 if ($print>=2) { print "Age of air tracer package: $age_of_air_trcs$eol"; }
+
+# Allow user to turn on the cldera sai tracers
+if (defined $opts{'cldera_sai_trcs'}) {
+    $cfg_ref->set('cldera_sai_trcs', $opts{'cldera_sai_trcs'});
+}
+my $cldera_sai_trcs = $cfg_ref->get('cldera_sai_trcs') ? "ON" : "OFF";
+if ($print>=2) { print "CLDERA SAI tracer package: $cldera_sai_trcs$eol"; }
 
 # waccmx option
 if (defined $opts{'waccmx'}) {
@@ -1036,6 +1048,7 @@ my $rad_pkg = 'rrtmg';
 if (defined $opts{'rad'}) {
     $rad_pkg = lc($opts{'rad'});
 }
+if ($phys_pkg =~ /ideal|adiabatic/) { $rad_pkg = 'none'; }
 $cfg_ref->set('rad', $rad_pkg);
 
 if ($print>=2) { print "Radiation package: $rad_pkg$eol"; }
@@ -1348,7 +1361,7 @@ if (!defined $opts{'cldera_strat_volc'}) {
     $opts{'cldera_strat_volc'} = 0;
 }
 my $cldera_strat_volc = $opts{'cldera_strat_volc'};
-   $cfg_ref->set('cldera_strat_volc', $cldera_strat_volc);
+$cfg_ref->set('cldera_strat_volc', $cldera_strat_volc);
 
 
 if (($chem_pkg ne 'none') || ($prog_species)) {
@@ -1385,7 +1398,6 @@ if ($chem_pkg =~ '_mam3') {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE_MOM ';
 } elsif ($chem_pkg =~ '_mam4' ) {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE ';
-} elsif ($chem_pkg =~ '_mam4' ) {
 } elsif ($chem_pkg =~ '_mam7') {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_7MODE ';
 } elsif ($chem_pkg =~ '_mam9') {
@@ -1408,6 +1420,7 @@ if ($cldera_strat_volc == 1 && ($chem_pkg =~ '_mam4' || $chem_pkg =~ '_mam4_mom'
 # Number of advected constituents
 my $nadv;
 if (defined $opts{'nadv'}) {
+
     $cfg_ref->set('nadv', $opts{'nadv'});
 }
 else {
@@ -1482,6 +1495,11 @@ else {
     if ($age_of_air_trcs eq "ON") {
 	$nadv += 4;
         if ($print>=2) { print "Advected constituents added by the age of air tracer package: 4$eol"; }
+    }
+
+    if ($cldera_sai_trcs eq "ON") {
+	$nadv += 5;
+        if ($print>=2) { print "Advected constituents added by the CLDERA SAI tracer package: 5$eol"; }
     }
 
     $cfg_ref->set('nadv', $nadv);
@@ -2617,7 +2635,13 @@ sub write_filepath
     print $fh "$camsrcdir/eam/src/chemistry/utils\n";
 
     # Add source code directories for selected radiation package
-    if ($rad eq 'rrtmg') {
+    # Note: need to add rad code even for rad none because source code in CAM
+    # physics folder needs constants defined in radconstants.F90. A better
+    # approach would be to separate components/eam/src/physics/cam into
+    # something like physics/share, physics/eam, and physics/ideal, and then
+    # only include the modules actually needed by the code. This would remove
+    # the need to build a rad package when no rad package is used.
+    if ($rad eq 'rrtmg' or $rad eq 'none') {
         print $fh "$camsrcdir/eam/src/physics/rrtmg\n";
         print $fh "$camsrcdir/eam/src/physics/rrtmg/ext/rrtmg_mcica\n";
         print $fh "$camsrcdir/eam/src/physics/rrtmg/ext/rrtmg_lw\n";

--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -335,6 +335,9 @@ GetOptions(
     "ccsm_seq"                  => \$opts{'ccsm_seq'},
     "cflags=s"                  => \$opts{'cflags'},
     "chem=s"                    => \$opts{'chem'},
+#++hybrown
+    "cldera_strat_volc=s"         => \$opts{'cldera_strat_volc'},
+#--hybrown
     "cice_bsizex=s"             => \$opts{'cice_bsizex'},
     "cice_bsizey=s"             => \$opts{'cice_bsizey'},
     "cice_maxblocks=s"          => \$opts{'cice_maxblocks'},
@@ -899,6 +902,10 @@ my $rain_evap_to_coarse_aero = $rain_evap_to_coarse_aero_opt ? 1:0;
 
 if ($print>=2) { print "Is rain_evap_to_coarse_aero active (0-NO; 1-YES)?: $rain_evap_to_coarse_aero$eol"; }
 
+# hybrown, turning on CLDERA prognostic stratospheric aerosol 
+# my $cldera_strat_volc_opt = (defined $opts{'cldera_strat_volc'}) ? 1 : 0;
+# $cfg_ref->set('cldera_strat_volc', $cldera_strat_volc_opt);
+# my $cldera_strat_volc = $cldera_strat_volc_opt ? 1:0;
 
 #-----------------------------------------------------------------------------------------------
 
@@ -1387,9 +1394,27 @@ if (($chem_pkg ne 'none') || ($prog_species)) {
 if ($chem_pkg =~ '_mam3') {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_3MODE ';
 } elsif ($chem_pkg =~ '_mam4_mom' || $chem_pkg =~ '_mam4_resus_mom' ) {
+#++hybrown, for turning on CLDERA stratospheric volcanic aerosol treatment
+#    $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE_MOM ';
+    if (!defined $opts{'cldera_strat_volc'} ) {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE_MOM ';
+    }
+    else{
+    my $cldera_strat_volc = $opts{'cldera_strat_volc'};
+        $cfg_ref->set('cldera_strat_volc', $cldera_strat_volc);
+    $chem_cppdefs = " -DMODAL_AERO -DMODAL_AERO_4MODE_MOM -DCLDERA_STRAT_VOLC=$cldera_strat_volc";
+    }
 } elsif ($chem_pkg =~ '_mam4' ) {
+#    $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE ';
+    if (!defined $opts{'cldera_strat_volc'} ) {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE ';
+    }
+    else{
+    my $cldera_strat_volc = $opts{'cldera_strat_volc'};
+        $cfg_ref->set('cldera_strat_volc', $cldera_strat_volc);
+    $chem_cppdefs = " -DMODAL_AERO -DMODAL_AERO_4MODE -DCLDERA_STRAT_VOLC=$cldera_strat_volc";
+    }
+#--hybrown
 } elsif ($chem_pkg =~ '_mam7') {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_7MODE ';
 } elsif ($chem_pkg =~ '_mam9') {
@@ -1403,6 +1428,12 @@ if ($bc_dep_to_snow_updates == 1) {
 if ($rain_evap_to_coarse_aero == 1 && ($chem_pkg =~ '_mam3' || $chem_pkg =~ '_mam4' || $chem_pkg eq 'trop_mam4_resus' || $chem_pkg eq 'trop_mam4_resus_soag' || $chem_pkg eq 'trop_mam4_resus_mom')) {
     $chem_cppdefs = "$chem_cppdefs  -DRAIN_EVAP_TO_COARSE_AERO "
 }
+
+# hybrown, using namelist option 'strat_accum_coarse_rename' to turn on CLDERA stratospheric prognostic aerosol treatment
+# Can configure read namelist options?
+#if ($strat_accum_coarse_rename == .true. && ($chem_pkg =~ '_mam4_mom' || $chem_pkg =~ '_mam4_resus_mom' || $chem_pkg =~ '_mam4_resus_mom_soag' )) {
+#    $chem_cppdefs = "$chem_cppdefs  -DCLDERA_STRAT_VOLC "
+#}
 
 #-----------------------------------------------------------------------------------------------
 # Number of advected constituents

--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -1382,18 +1382,20 @@ if (($chem_pkg ne 'none') || ($prog_species)) {
 if ($chem_pkg =~ '_mam3') {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_3MODE ';
 } elsif ($chem_pkg =~ '_mam4_mom' || $chem_pkg =~ '_mam4_resus_mom' ) {
-    if ($cldera_strat_volc == 1) {
-        $chem_cppdefs = " -DMODAL_AERO -DMODAL_AERO_4MODE_MOM -DCLDERA_STRAT_VOLC=$cldera_strat_volc";
-    } else {
-        $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE_MOM ';
-    }   
+#    if ($cldera_strat_volc == 1) {
+#        print "cldera_strat_volc: $cldera_strat_volc"
+#        $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE_MOM -DCLDERA_STRAT_VOLC ';
+#    } else {
+#        print "cldera_strat_volc: $cldera_strat_volc"
+    $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE_MOM ';
+#    }   
 
 } elsif ($chem_pkg =~ '_mam4' ) {
-    if ($cldera_strat_volc == 1) {
-        $chem_cppdefs = " -DMODAL_AERO -DMODAL_AERO_4MODE -DCLDERA_STRAT_VOLC=$cldera_strat_volc";
-    } else {
-        $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE ';
-    }
+#    if ($cldera_strat_volc == 1) {
+#        $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE -DCLDERA_STRAT_VOLC ';
+#    } else {
+    $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE ';
+#    }
 } elsif ($chem_pkg =~ '_mam4' ) {
 } elsif ($chem_pkg =~ '_mam7') {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_7MODE ';
@@ -1407,6 +1409,10 @@ if ($bc_dep_to_snow_updates == 1) {
 
 if ($rain_evap_to_coarse_aero == 1 && ($chem_pkg =~ '_mam3' || $chem_pkg =~ '_mam4' || $chem_pkg eq 'trop_mam4_resus' || $chem_pkg eq 'trop_mam4_resus_soag' || $chem_pkg eq 'trop_mam4_resus_mom')) {
     $chem_cppdefs = "$chem_cppdefs  -DRAIN_EVAP_TO_COARSE_AERO "
+}
+
+if ($cldera_strat_volc == 1 && ($chem_pkg =~ '_mam4' || $chem_pkg =~ '_mam4_mom' || $chem_pkg =~ 'mam4_resus_mom')) {
+    $chem_cppdefs = "$chem_cppdefs  -DCLDERA_STRAT_VOLC "
 }
 
 #-----------------------------------------------------------------------------------------------

--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -112,7 +112,6 @@ OPTIONS
   effect whether running EAM as part of CCSM or running in a EAM standalone mode:
 
      -[no]age_of_air_trcs Switch on [off] age of air tracers. Default: on for waccm_phys, otherwise off
-     -cldera_sai_trcs   Switch on idealized stratospheric aerosol injection tracers. Default: off
      -aquaplanet        Switch on aqua-planet mode w/ SST controlled by data ocean component in CIME
      -rce               Use homogenous conditions for radiative-convective equilibrium (RCE), normally used with aquaplanet
      -chem <name>       Build EAM with specified prognostic chemistry package
@@ -162,7 +161,7 @@ OPTIONS
                         The user does not need to set this if one of the waccm chemistry options
                         is chosen.
      -waccmx            Build EAM/WACCM with WACCM upper Thermosphere/Ionosphere extended package
-     
+
 
   Options relevent to SCAM mode:
 
@@ -281,10 +280,6 @@ OPTIONS
      -crm_adv           CRM advection scheme [MPDATA | UM5]
      -crm <model>       CRM model [sam | samomp | samxx]
      -rrtmgpxx          Use RRTMGP++ code
-
-  Options for CLDERA-E3SM
-
-     -cldera_profiling  Build EAM with support for CLDERA profiling, linking to cldera-profiling
 EOF
 }
 
@@ -322,7 +317,6 @@ my %opts = (
 	    );
 GetOptions(
     "age_of_air_trcs!"          => \$opts{'age_of_air_trcs'},
-    "cldera_sai_trcs!"          => \$opts{'cldera_sai_trcs'},
     "aquaplanet"                => \$opts{'aquaplanet'},
     "cache=s"                   => \$opts{'cache'},
     "cachedir=s"                => \$opts{'cachedir'},
@@ -335,7 +329,7 @@ GetOptions(
     "ccsm_seq"                  => \$opts{'ccsm_seq'},
     "cflags=s"                  => \$opts{'cflags'},
     "chem=s"                    => \$opts{'chem'},
-    "cldera_strat_volc=s"         => \$opts{'cldera_strat_volc'},
+    "cldera_strat_volc=s"       => \$opts{'cldera_strat_volc'},
     "cice_bsizex=s"             => \$opts{'cice_bsizex'},
     "cice_bsizey=s"             => \$opts{'cice_bsizey'},
     "cice_maxblocks=s"          => \$opts{'cice_maxblocks'},
@@ -356,11 +350,10 @@ GetOptions(
     "crm_dt=s"                  => \$opts{'crm_dt'},
     "crm_nx_rad=s"              => \$opts{'crm_nx_rad'},
     "crm_ny_rad=s"              => \$opts{'crm_ny_rad'},
-    "MMF_microphysics_scheme=s"     => \$opts{'MMF_microphysics_scheme'},
+    "MMF_microphysics_scheme=s" => \$opts{'MMF_microphysics_scheme'},
     "crm_adv=s"                 => \$opts{'crm_adv'},
     "crm=s"                     => \$opts{'crm'},
     "rrtmgpxx"                  => \$opts{'rrtmgpxx'},
-    "cldera_profiling"          => \$opts{'cldera_profiling'},
     "debug"                     => \$opts{'debug'},
     "rain_evap_to_coarse_aero"  => \$opts{'rain_evap_to_coarse_aero'},
     "bc_dep_to_snow_updates"    => \$opts{'bc_dep_to_snow_updates'},
@@ -871,14 +864,8 @@ if (defined $opts{'age_of_air_trcs'}) {
     $cfg_ref->set('age_of_air_trcs', $opts{'age_of_air_trcs'});
 }
 my $age_of_air_trcs = $cfg_ref->get('age_of_air_trcs') ? "ON" : "OFF";
-if ($print>=2) { print "Age of air tracer package: $age_of_air_trcs$eol"; }
 
-# Allow user to turn on the cldera sai tracers
-if (defined $opts{'cldera_sai_trcs'}) {
-    $cfg_ref->set('cldera_sai_trcs', $opts{'cldera_sai_trcs'});
-}
-my $cldera_sai_trcs = $cfg_ref->get('cldera_sai_trcs') ? "ON" : "OFF";
-if ($print>=2) { print "CLDERA SAI tracer package: $cldera_sai_trcs$eol"; }
+if ($print>=2) { print "Age of air tracer package: $age_of_air_trcs$eol"; }
 
 # waccmx option
 if (defined $opts{'waccmx'}) {
@@ -1049,7 +1036,6 @@ my $rad_pkg = 'rrtmg';
 if (defined $opts{'rad'}) {
     $rad_pkg = lc($opts{'rad'});
 }
-if ($phys_pkg =~ /ideal|adiabatic/) { $rad_pkg = 'none'; }
 $cfg_ref->set('rad', $rad_pkg);
 
 if ($print>=2) { print "Radiation package: $rad_pkg$eol"; }
@@ -1356,6 +1342,15 @@ if (!$prog_species) {
   $cfg_ref->set('chem_src_dir', $chem_src_dir);
 }
 
+#CLDERA stratospheric volcanic aerosol treatment
+#initialize if not specified in cam_config_opts
+if (!defined $opts{'cldera_strat_volc'}) {
+    $opts{'cldera_strat_volc'} = 0;
+}
+my $cldera_strat_volc = $opts{'cldera_strat_volc'};
+   $cfg_ref->set('cldera_strat_volc', $cldera_strat_volc);
+
+
 if (($chem_pkg ne 'none') || ($prog_species)) {
 
     # customize chemistry
@@ -1387,25 +1382,17 @@ if (($chem_pkg ne 'none') || ($prog_species)) {
 if ($chem_pkg =~ '_mam3') {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_3MODE ';
 } elsif ($chem_pkg =~ '_mam4_mom' || $chem_pkg =~ '_mam4_resus_mom' ) {
-#for turning on CLDERA stratospheric volcanic aerosol treatment
-#    $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE_MOM ';
-    if (!defined $opts{'cldera_strat_volc'} ) {
-    $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE_MOM ';
-    }
-    else{
-    my $cldera_strat_volc = $opts{'cldera_strat_volc'};
-        $cfg_ref->set('cldera_strat_volc', $cldera_strat_volc);
-    $chem_cppdefs = " -DMODAL_AERO -DMODAL_AERO_4MODE_MOM -DCLDERA_STRAT_VOLC=$cldera_strat_volc";
-    }
+    if ($cldera_strat_volc == 1) {
+        $chem_cppdefs = " -DMODAL_AERO -DMODAL_AERO_4MODE_MOM -DCLDERA_STRAT_VOLC=$cldera_strat_volc";
+    } else {
+        $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE_MOM ';
+    }   
+
 } elsif ($chem_pkg =~ '_mam4' ) {
-#    $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE ';
-    if (!defined $opts{'cldera_strat_volc'} ) {
-    $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE ';
-    }
-    else{
-    my $cldera_strat_volc = $opts{'cldera_strat_volc'};
-        $cfg_ref->set('cldera_strat_volc', $cldera_strat_volc);
-    $chem_cppdefs = " -DMODAL_AERO -DMODAL_AERO_4MODE -DCLDERA_STRAT_VOLC=$cldera_strat_volc";
+    if ($cldera_strat_volc == 1) {
+        $chem_cppdefs = " -DMODAL_AERO -DMODAL_AERO_4MODE -DCLDERA_STRAT_VOLC=$cldera_strat_volc";
+    } else {
+        $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_4MODE ';
     }
 } elsif ($chem_pkg =~ '_mam4' ) {
 } elsif ($chem_pkg =~ '_mam7') {
@@ -1426,7 +1413,6 @@ if ($rain_evap_to_coarse_aero == 1 && ($chem_pkg =~ '_mam3' || $chem_pkg =~ '_ma
 # Number of advected constituents
 my $nadv;
 if (defined $opts{'nadv'}) {
-
     $cfg_ref->set('nadv', $opts{'nadv'});
 }
 else {
@@ -1501,11 +1487,6 @@ else {
     if ($age_of_air_trcs eq "ON") {
 	$nadv += 4;
         if ($print>=2) { print "Advected constituents added by the age of air tracer package: 4$eol"; }
-    }
-    
-    if ($cldera_sai_trcs eq "ON") {
-	$nadv += 5;
-        if ($print>=2) { print "Advected constituents added by the CLDERA SAI tracer package: 5$eol"; }
     }
 
     $cfg_ref->set('nadv', $nadv);
@@ -2641,13 +2622,7 @@ sub write_filepath
     print $fh "$camsrcdir/eam/src/chemistry/utils\n";
 
     # Add source code directories for selected radiation package
-    # Note: need to add rad code even for rad none because source code in CAM
-    # physics folder needs constants defined in radconstants.F90. A better
-    # approach would be to separate components/eam/src/physics/cam into
-    # something like physics/share, physics/eam, and physics/ideal, and then
-    # only include the modules actually needed by the code. This would remove
-    # the need to build a rad package when no rad package is used.
-    if ($rad eq 'rrtmg' or $rad eq 'none') {
+    if ($rad eq 'rrtmg') {
         print $fh "$camsrcdir/eam/src/physics/rrtmg\n";
         print $fh "$camsrcdir/eam/src/physics/rrtmg/ext/rrtmg_mcica\n";
         print $fh "$camsrcdir/eam/src/physics/rrtmg/ext/rrtmg_lw\n";

--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -902,11 +902,6 @@ my $rain_evap_to_coarse_aero = $rain_evap_to_coarse_aero_opt ? 1:0;
 
 if ($print>=2) { print "Is rain_evap_to_coarse_aero active (0-NO; 1-YES)?: $rain_evap_to_coarse_aero$eol"; }
 
-# hybrown, turning on CLDERA prognostic stratospheric aerosol 
-# my $cldera_strat_volc_opt = (defined $opts{'cldera_strat_volc'}) ? 1 : 0;
-# $cfg_ref->set('cldera_strat_volc', $cldera_strat_volc_opt);
-# my $cldera_strat_volc = $cldera_strat_volc_opt ? 1:0;
-
 #-----------------------------------------------------------------------------------------------
 
 # Prognostic species package(s)
@@ -1415,6 +1410,7 @@ if ($chem_pkg =~ '_mam3') {
     $chem_cppdefs = " -DMODAL_AERO -DMODAL_AERO_4MODE -DCLDERA_STRAT_VOLC=$cldera_strat_volc";
     }
 #--hybrown
+} elsif ($chem_pkg =~ '_mam4' ) {
 } elsif ($chem_pkg =~ '_mam7') {
     $chem_cppdefs = ' -DMODAL_AERO -DMODAL_AERO_7MODE ';
 } elsif ($chem_pkg =~ '_mam9') {
@@ -1428,12 +1424,6 @@ if ($bc_dep_to_snow_updates == 1) {
 if ($rain_evap_to_coarse_aero == 1 && ($chem_pkg =~ '_mam3' || $chem_pkg =~ '_mam4' || $chem_pkg eq 'trop_mam4_resus' || $chem_pkg eq 'trop_mam4_resus_soag' || $chem_pkg eq 'trop_mam4_resus_mom')) {
     $chem_cppdefs = "$chem_cppdefs  -DRAIN_EVAP_TO_COARSE_AERO "
 }
-
-# hybrown, using namelist option 'strat_accum_coarse_rename' to turn on CLDERA stratospheric prognostic aerosol treatment
-# Can configure read namelist options?
-#if ($strat_accum_coarse_rename == .true. && ($chem_pkg =~ '_mam4_mom' || $chem_pkg =~ '_mam4_resus_mom' || $chem_pkg =~ '_mam4_resus_mom_soag' )) {
-#    $chem_cppdefs = "$chem_cppdefs  -DCLDERA_STRAT_VOLC "
-#}
 
 #-----------------------------------------------------------------------------------------------
 # Number of advected constituents

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -286,8 +286,8 @@
 <mam4_mode3_file rad="rrtmg">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc</mam4_mode3_file>
 <mam4_mode4_file rad="rrtmg">atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc</mam4_mode4_file>
 <!-- for CLDERA stratospheric aerosol treatment-->
-<mam4_mode1_file rad="rrtmg" cldera_strat_volc="1">/projects/cldera/data/E3SM/model_input/modal_optics/modal_optics_mode1_hb.nc</mam4_mode1_file>
-<mam4_mode3_file rad="rrtmg" cldera_strat_volc="1">/projects/cldera/data/E3SM/model_input/modal_optics/modal_optics_mode3_hb.nc</mam4_mode3_file>
+<mam4_mode1_file rad="rrtmg" cldera_strat_volc="1">/atm/cldera/modal_optics/modal_optics_mode1_hb.nc</mam4_mode1_file>
+<mam4_mode3_file rad="rrtmg" cldera_strat_volc="1">/atm/cldera/modal_optics/modal_optics_mode3_hb.nc</mam4_mode3_file>
 
 <mam7_mode1_file rad="rrtmg">atm/cam/physprops/mam7_mode1_rrtmg_c120904.nc</mam7_mode1_file>
 <mam7_mode2_file rad="rrtmg">atm/cam/physprops/mam7_mode2_rrtmg_c120904.nc</mam7_mode2_file>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -338,6 +338,8 @@
 <water_refindex_file rad="rrtmg">atm/cam/physprops/water_refindex_rrtmg_c080910.nc</water_refindex_file>
 <water_refindex_file rad="rrtmgp">atm/cam/physprops/water_refindex_rrtmg_c080910.nc</water_refindex_file>
 
+<!-- turning on stratospheric volcanic aerosol renaming, hybrown -->
+<strat_accum_coarse_rename            >.false.</strat_accum_coarse_rename>
 
 <!-- Cloud optics for RRTMG -->
 <liqcldoptics  rad="rrtmg" microphys="rk">slingo</liqcldoptics>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -341,9 +341,6 @@
 <water_refindex_file rad="rrtmg">atm/cam/physprops/water_refindex_rrtmg_c080910.nc</water_refindex_file>
 <water_refindex_file rad="rrtmgp">atm/cam/physprops/water_refindex_rrtmg_c080910.nc</water_refindex_file>
 
-<!-- turning on stratospheric volcanic aerosol renaming, hybrown -->
-<strat_accum_coarse_rename            >.false.</strat_accum_coarse_rename>
-
 <!-- Cloud optics for RRTMG -->
 <liqcldoptics  rad="rrtmg" microphys="rk">slingo</liqcldoptics>
 <icecldoptics  rad="rrtmg" microphys="rk">ebertcurry</icecldoptics>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -285,7 +285,7 @@
 <mam4_mode2_file rad="rrtmg">atm/cam/physprops/mam4_mode2_rrtmg_c130628.nc</mam4_mode2_file>
 <mam4_mode3_file rad="rrtmg">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc</mam4_mode3_file>
 <mam4_mode4_file rad="rrtmg">atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc</mam4_mode4_file>
-<!-- hybrown -->
+<!-- for CLDERA stratospheric aerosol treatment-->
 <mam4_mode1_file rad="rrtmg" cldera_strat_volc="1">/projects/cldera/data/E3SM/model_input/modal_optics/modal_optics_mode1_hb.nc</mam4_mode1_file>
 <mam4_mode3_file rad="rrtmg" cldera_strat_volc="1">/projects/cldera/data/E3SM/model_input/modal_optics/modal_optics_mode3_hb.nc</mam4_mode3_file>
 
@@ -1735,10 +1735,9 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <clubb_use_sgv phys="default"> .true.     </clubb_use_sgv>
 <seasalt_emis_scale phys="default" chem="linoz_mam4_resus_mom_soag"> 0.6        </seasalt_emis_scale>
 
-<!--hybrown -->
+<!-- for CLDERA stratospheric aerosol treatment-->
 <seasalt_emis_scale phys="default" chem="linoz_mam4_resus_mom_soag" cldera_strat_volc="1"> 0.36        </seasalt_emis_scale>
 <dust_emis_fact phys="default" cldera_strat_volc="1"> 3.255D0     </dust_emis_fact>
-<!--hybrown -->
 
 <zmconv_c0_lnd phys="default"> 0.0020     </zmconv_c0_lnd>
 <zmconv_c0_ocn phys="default"> 0.0020     </zmconv_c0_ocn>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -286,8 +286,8 @@
 <mam4_mode3_file rad="rrtmg">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc</mam4_mode3_file>
 <mam4_mode4_file rad="rrtmg">atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc</mam4_mode4_file>
 <!-- for CLDERA stratospheric aerosol treatment-->
-<mam4_mode1_file rad="rrtmg" cldera_strat_volc="1">/atm/cldera/modal_optics/modal_optics_mode1_hb.nc</mam4_mode1_file>
-<mam4_mode3_file rad="rrtmg" cldera_strat_volc="1">/atm/cldera/modal_optics/modal_optics_mode3_hb.nc</mam4_mode3_file>
+<mam4_mode1_file rad="rrtmg" cldera_strat_volc="1">atm/cldera/modal_optics/modal_optics_mode1_hb.nc</mam4_mode1_file>
+<mam4_mode3_file rad="rrtmg" cldera_strat_volc="1">atm/cldera/modal_optics/modal_optics_mode3_hb.nc</mam4_mode3_file>
 
 <mam7_mode1_file rad="rrtmg">atm/cam/physprops/mam7_mode1_rrtmg_c120904.nc</mam7_mode1_file>
 <mam7_mode2_file rad="rrtmg">atm/cam/physprops/mam7_mode2_rrtmg_c120904.nc</mam7_mode2_file>
@@ -404,6 +404,11 @@
 
 <!-- Volcanic Aerosol Mass -->
 <bndtvvolc>atm/cam/rad/VolcanicMass_1870-1999_64x1_L18_c040115.nc</bndtvvolc>
+
+<!-- Removing prescribed volcanic forcing for CLDERA -->
+<prescribed_volcaero_filetype cldera_strat_volc="1">VOLC_MIXING_RATIO</prescribed_volcaero_filetype>
+<prescribed_volcaero_datapath cldera_strat_volc="1">atm/cldera/emissions/volc/zero-presc-volc-mmr</prescribed_volcaero_datapath>
+<prescribed_volcaero_file cldera_strat_volc="1">BMW_volcanic_1850-3009_all_zero.nc</prescribed_volcaero_file>
 
 <!-- Tropopause climatology -->
 <tropopause_climo_file>atm/cam/chem/trop_mozart/ub/clim_p_trop.nc</tropopause_climo_file>
@@ -616,6 +621,8 @@
 <bc_a1_ext_file    ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_elev_2000_c120315.nc </bc_a1_ext_file>
 <bc_a3_ext_file    ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_elev_2000_c120315.nc </bc_a3_ext_file>
 <bc_a4_ext_file    ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_elev_2000_c120315.nc </bc_a4_ext_file>
+<!-- CLDERA merged volcanic emission files -->
+<so2_ext_file  cldera_strat_volc="1">atm/cldera/emissions/volc/merge_cmip6_and_volc_so2/merged_cmip6_and_volc_so2.nc </so2_ext_file>
 
 <mam7_num_a1_emis_file >atm/cam/chem/trop_mozart_aero/emis/ar5_mam7_num_a1_surf_2000_c120716.nc</mam7_num_a1_emis_file>
 <mam7_num_a3_emis_file >atm/cam/chem/trop_mozart_aero/emis/ar5_mam7_num_a3_surf_2000_c120716.nc</mam7_num_a3_emis_file>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -285,6 +285,9 @@
 <mam4_mode2_file rad="rrtmg">atm/cam/physprops/mam4_mode2_rrtmg_c130628.nc</mam4_mode2_file>
 <mam4_mode3_file rad="rrtmg">atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc</mam4_mode3_file>
 <mam4_mode4_file rad="rrtmg">atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc</mam4_mode4_file>
+<!-- hybrown -->
+<mam4_mode1_file rad="rrtmg" cldera_strat_volc="1">/projects/cldera/data/E3SM/model_input/modal_optics/modal_optics_mode1_hb.nc</mam4_mode1_file>
+<mam4_mode3_file rad="rrtmg" cldera_strat_volc="1">/projects/cldera/data/E3SM/model_input/modal_optics/modal_optics_mode3_hb.nc</mam4_mode3_file>
 
 <mam7_mode1_file rad="rrtmg">atm/cam/physprops/mam7_mode1_rrtmg_c120904.nc</mam7_mode1_file>
 <mam7_mode2_file rad="rrtmg">atm/cam/physprops/mam7_mode2_rrtmg_c120904.nc</mam7_mode2_file>
@@ -941,7 +944,6 @@
 
 <dust_emis_fact dyn="se"                   phys="cam5"                  >0.55D0</dust_emis_fact>
 <dust_emis_fact dyn="fv"                   phys="cam5" clubb_sgs="1"    >0.13D0</dust_emis_fact>
-
 
 <!-- Sea Salt tuning option for scavenging mods by PNNL -->
 <ssalt_tuning>.false.</ssalt_tuning>
@@ -1735,6 +1737,12 @@ with se_tstep, dt_remap_factor, dt_tracer_factor set to -1
 <clubb_ice_deep phys="default"> 14.e-6     </clubb_ice_deep>
 <clubb_use_sgv phys="default"> .true.     </clubb_use_sgv>
 <seasalt_emis_scale phys="default" chem="linoz_mam4_resus_mom_soag"> 0.6        </seasalt_emis_scale>
+
+<!--hybrown -->
+<seasalt_emis_scale phys="default" chem="linoz_mam4_resus_mom_soag" cldera_strat_volc="1"> 0.36        </seasalt_emis_scale>
+<dust_emis_fact phys="default" cldera_strat_volc="1"> 3.255D0     </dust_emis_fact>
+<!--hybrown -->
+
 <zmconv_c0_lnd phys="default"> 0.0020     </zmconv_c0_lnd>
 <zmconv_c0_ocn phys="default"> 0.0020     </zmconv_c0_ocn>
 <zmconv_alfa phys="default"> 0.14D0     </zmconv_alfa>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -405,11 +405,6 @@
 <!-- Volcanic Aerosol Mass -->
 <bndtvvolc>atm/cam/rad/VolcanicMass_1870-1999_64x1_L18_c040115.nc</bndtvvolc>
 
-<!-- Removing prescribed volcanic forcing for CLDERA -->
-<prescribed_volcaero_filetype cldera_strat_volc="1">VOLC_MIXING_RATIO</prescribed_volcaero_filetype>
-<prescribed_volcaero_datapath cldera_strat_volc="1">atm/cldera/emissions/volc/zero-presc-volc-mmr</prescribed_volcaero_datapath>
-<prescribed_volcaero_file cldera_strat_volc="1">BMW_volcanic_1850-3009_all_zero.nc</prescribed_volcaero_file>
-
 <!-- Tropopause climatology -->
 <tropopause_climo_file>atm/cam/chem/trop_mozart/ub/clim_p_trop.nc</tropopause_climo_file>
 
@@ -621,8 +616,6 @@
 <bc_a1_ext_file    ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_elev_2000_c120315.nc </bc_a1_ext_file>
 <bc_a3_ext_file    ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_elev_2000_c120315.nc </bc_a3_ext_file>
 <bc_a4_ext_file    ver="mam">atm/cam/chem/trop_mozart_aero/emis/ar5_mam3_bc_elev_2000_c120315.nc </bc_a4_ext_file>
-<!-- CLDERA merged volcanic emission files -->
-<so2_ext_file  cldera_strat_volc="1">atm/cldera/emissions/volc/merge_cmip6_and_volc_so2/merged_cmip6_and_volc_so2.nc </so2_ext_file>
 
 <mam7_num_a1_emis_file >atm/cam/chem/trop_mozart_aero/emis/ar5_mam7_num_a1_surf_2000_c120716.nc</mam7_num_a1_emis_file>
 <mam7_num_a3_emis_file >atm/cam/chem/trop_mozart_aero/emis/ar5_mam7_num_a3_surf_2000_c120716.nc</mam7_num_a3_emis_file>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -4497,6 +4497,12 @@ Tuning parameter for dust emissions.
 Default: set by build-namelist.
 </entry>
 
+<!-- stratospheric accumulation to coarse mode renaming flag, hybrown -->
+<entry id="strat_accum_coarse_rename" type="logical" category="cam_chem"
+       group="aerosol_nl" valid_values="" >
+Turns on accumulation to coarse mode exchange ("renaming" in MAM) in the stratosphere.
+Default: .false. 
+
 <!-- sea salt tuning flag for polar project -->
 <entry id="ssalt_tuning"  type="logical" category="cam_chem"
        group="phys_ctl_nl" valid_values="" >

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -4497,12 +4497,6 @@ Tuning parameter for dust emissions.
 Default: set by build-namelist.
 </entry>
 
-<!-- stratospheric accumulation to coarse mode renaming flag, hybrown -->
-<entry id="strat_accum_coarse_rename" type="logical" category="cam_chem"
-       group="aerosol_nl" valid_values="" >
-Turns on accumulation to coarse mode exchange ("renaming" in MAM) in the stratosphere.
-Default: .false. 
-
 <!-- sea salt tuning flag for polar project -->
 <entry id="ssalt_tuning"  type="logical" category="cam_chem"
        group="phys_ctl_nl" valid_values="" >

--- a/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6.xml
@@ -22,6 +22,11 @@
 <prescribed_volcaero_filetype>VOLC_CMIP6					       </prescribed_volcaero_filetype>
 <prescribed_volcaero_type    >CYCLICAL						       </prescribed_volcaero_type    >
 <prescribed_volcaero_cycle_yr>1                                                        </prescribed_volcaero_cycle_yr>
+<!-- Removing prescribed volcanic forcing for CLDERA -->
+<prescribed_volcaero_filetype cldera_strat_volc="1">VOLC_MIXING_RATIO                            </prescribed_volcaero_filetype>
+<prescribed_volcaero_datapath cldera_strat_volc="1">atm/cldera/emissions/volc/zero-presc-volc-mmr</prescribed_volcaero_datapath>
+<prescribed_volcaero_file cldera_strat_volc="1">BMW_volcanic_1850-3009_all_zero.nc               </prescribed_volcaero_file>
+<prescribed_volcaero_cycle_yr cldera_strat_volc="1">1850                                         </prescribed_volcaero_cycle_yr>
 
 <!-- For comprehensive history -->
 <history_amwg       >.true.</history_amwg>
@@ -40,6 +45,8 @@
 <pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc </pom_a4_ext_file>
 <so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc </so4_a1_ext_file>
 <so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc </so4_a2_ext_file>
+<!-- CLDERA merged volcanic emission files -->
+<so2_ext_file  cldera_strat_volc="1">atm/cldera/emissions/volc/merge_cmip6_and_volc_so2/merged_cmip6_and_volc_so2.nc </so2_ext_file>
 
 <!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
 <srf_emis_type        >CYCLICAL</srf_emis_type>

--- a/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/1850_eam_CMIP6.xml
@@ -46,7 +46,7 @@
 <so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc </so4_a1_ext_file>
 <so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc </so4_a2_ext_file>
 <!-- CLDERA merged volcanic emission files -->
-<so2_ext_file  cldera_strat_volc="1">atm/cldera/emissions/volc/merge_cmip6_and_volc_so2/merged_cmip6_and_volc_so2.nc </so2_ext_file>
+<so2_ext_file  cldera_strat_volc="1">atm/cldera/emissions/volc/merge_cmip6_and_volc_so2/merged_cmip6_and_VolcanEESMv3.10_piControl_SO2_1850-2014average_2deg_ZeroTrop_c190701.nc </so2_ext_file>
 
 <!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
 <srf_emis_type        >CYCLICAL</srf_emis_type>

--- a/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6.xml
@@ -17,6 +17,10 @@
 <prescribed_volcaero_file>CMIP_DOE-ACME_radiation_1850-2014_v3_c20171205.nc</prescribed_volcaero_file>
 <prescribed_volcaero_filetype>VOLC_CMIP6</prescribed_volcaero_filetype>
 <prescribed_volcaero_type>SERIAL</prescribed_volcaero_type>
+<!-- Removing prescribed volcanic forcing for CLDERA -->
+<prescribed_volcaero_filetype cldera_strat_volc="1">VOLC_MIXING_RATIO</prescribed_volcaero_filetype>
+<prescribed_volcaero_datapath cldera_strat_volc="1">atm/cldera/emissions/volc/zero-presc-volc-mmr</prescribed_volcaero_datapath>
+<prescribed_volcaero_file cldera_strat_volc="1">BMW_volcanic_1850-3009_all_zero.nc</prescribed_volcaero_file>
 
 <!-- For comprehensive history -->
 <history_amwg>.true.</history_amwg>

--- a/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6.xml
@@ -39,7 +39,7 @@
 <so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc </so4_a1_ext_file>
 <so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc </so4_a2_ext_file>
 <!-- CLDERA merged volcanic emission files -->
-<so2_ext_file  cldera_strat_volc="1">atm/cldera/emissions/volc/merge_cmip6_and_volc_so2/merged_cmip6_and_volc_so2.nc </so2_ext_file>
+<so2_ext_file  cldera_strat_volc="1">atm/cldera/emissions/volc/merge_cmip6_and_volc_so2/merged_cmip6_and_VolcanEESMv3.11_1850-1999_180x360_c20220808.nc </so2_ext_file>
 
 <!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
 <srf_emis_type>INTERP_MISSING_MONTHS</srf_emis_type>

--- a/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6.xml
@@ -34,6 +34,8 @@
 <pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc </pom_a4_ext_file>
 <so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc </so4_a1_ext_file>
 <so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc </so4_a2_ext_file>
+<!-- CLDERA merged volcanic emission files -->
+<so2_ext_file  cldera_strat_volc="1">atm/cldera/emissions/volc/merge_cmip6_and_volc_so2/merged_cmip6_and_volc_so2.nc </so2_ext_file>
 
 <!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
 <srf_emis_type>INTERP_MISSING_MONTHS</srf_emis_type>

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/cldera_strat_volc/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/cldera_strat_volc/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange --append CAM_CONFIG_OPTS="-cldera_strat_volc 1"

--- a/components/eam/src/chemistry/bulk_aero/aero_model.F90
+++ b/components/eam/src/chemistry/bulk_aero/aero_model.F90
@@ -1012,7 +1012,7 @@ contains
   !=============================================================================
   !=============================================================================
   subroutine aero_model_gasaerexch( loffset, ncol, lchnk, delt, latndx, lonndx, reaction_rates, &
-                                    tfld, pmid, pdel, mbar, relhum, &
+                                    tfld, pmid, pdel, troplev, mbar, relhum, &
                                     zm,  qh2o, cwat, cldfr, cldnum, &
                                     airdens, invariants, del_h2so4_gasprod,  &
                                     vmr0, vmr, pbuf )
@@ -1029,6 +1029,7 @@ contains
     integer,  intent(in) :: ncol                   ! number columns in chunk
     integer,  intent(in) :: lchnk                  ! chunk index
     real(r8), intent(in) :: delt                   ! time step size (sec)
+    integer,  intent(in) :: troplev(pcols)         ! tropopause level index
     real(r8), intent(in) :: reaction_rates(:,:,:)  ! reaction rates
     real(r8), intent(in) :: tfld(:,:)              ! temperature (K)
     real(r8), intent(in) :: pmid(:,:)              ! pressure at model levels (Pa)

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -107,8 +107,6 @@ module aero_model
   logical :: drydep_lq(pcnst)
   logical :: wetdep_lq(pcnst)
 
-  !logical :: strat_accum_coarse_rename = .false. !hybrown
-
 contains
   
   !=============================================================================
@@ -131,7 +129,7 @@ contains
     character(len=16) :: aer_drydep_list(pcnst) = ' '
 
     namelist /aerosol_nl/ aer_wetdep_list, aer_drydep_list, sol_facti_cloud_borne, seasalt_emis_scale, sscav_tuning, &
-       sol_factb_interstitial, sol_factic_interstitial !, strat_accum_coarse_rename !hybrown
+       sol_factb_interstitial, sol_factic_interstitial
 
     !-----------------------------------------------------------------------------
 
@@ -160,7 +158,6 @@ contains
     call mpibcast(sol_factic_interstitial, 1,                       mpir8,   0, mpicom)
     call mpibcast(sscav_tuning,          1,                         mpilog,  0, mpicom)
     call mpibcast(seasalt_emis_scale, 1, mpir8,   0, mpicom)
-    !call mpibcast(strat_accum_coarse_rename, 1,                     mpilog,  0, mpicom) !hybrown
 #endif
 
     wetdep_list = aer_wetdep_list
@@ -356,7 +353,7 @@ contains
     endif
     call rad_cnst_get_info(0, nmodes=nmodes)
 
-    call modal_aero_initialize(pbuf2d, imozart, species_class) !, strat_accum_coarse_rename) !hybrown
+    call modal_aero_initialize(pbuf2d, imozart, species_class)
     call modal_aero_bcscavcoef_init()
     call mam_prevap_resusp_init( ) ! REASTER 08/04/2015
 

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -2362,7 +2362,7 @@ do_lphase2_conditional: &
   !=============================================================================
   subroutine aero_model_gasaerexch( loffset, ncol, lchnk, delt, &
                                     latndx, lonndx, reaction_rates, &
-                                    tfld, pmid, pdel, troplev, mbar, relhum, & !hybrown, added troplev
+                                    tfld, pmid, pdel, troplev, mbar, relhum, &
                                     zm,  qh2o, cwat, cldfr, cldnum, &
                                     airdens, invariants, del_h2so4_gasprod,  &
                                     vmr0, vmr, pbuf )
@@ -2384,7 +2384,7 @@ do_lphase2_conditional: &
     integer,  intent(in) :: lchnk                  ! chunk index
     integer,  intent(in) :: latndx(pcols)          ! latitude indices
     integer,  intent(in) :: lonndx(pcols)          ! longitude indices
-    integer,  intent(in) :: troplev(pcols)         ! hybrown, tropopause level index
+    integer,  intent(in) :: troplev(pcols)         ! tropopause level index
     real(r8), intent(in) :: delt                   ! time step size (sec)
     real(r8), intent(in) :: reaction_rates(:,:,:)  ! reaction rates
     real(r8), intent(in) :: tfld(:,:)              ! temperature (K)
@@ -2591,7 +2591,7 @@ do_lphase2_conditional: &
             loffset,   delt,                         &
             latndx,    lonndx,                       &
             tfld,      pmid,    pdel,                &
-            troplev,                                 & !hybrown
+            troplev,                                 &
             zm,        pblh,                         &
             qh2o,      cldfr,                        &
             vmr,                vmrcw,               &

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -2363,7 +2363,7 @@ do_lphase2_conditional: &
   !=============================================================================
   subroutine aero_model_gasaerexch( loffset, ncol, lchnk, delt, &
                                     latndx, lonndx, reaction_rates, &
-                                    tfld, pmid, pdel, mbar, relhum, &
+                                    tfld, pmid, pdel, troplev, mbar, relhum, & !hybrown, added troplev
                                     zm,  qh2o, cwat, cldfr, cldnum, &
                                     airdens, invariants, del_h2so4_gasprod,  &
                                     vmr0, vmr, pbuf )
@@ -2385,6 +2385,7 @@ do_lphase2_conditional: &
     integer,  intent(in) :: lchnk                  ! chunk index
     integer,  intent(in) :: latndx(pcols)          ! latitude indices
     integer,  intent(in) :: lonndx(pcols)          ! longitude indices
+    integer,  intent(in) :: troplev(pcols)         ! hybrown, tropopause level index
     real(r8), intent(in) :: delt                   ! time step size (sec)
     real(r8), intent(in) :: reaction_rates(:,:,:)  ! reaction rates
     real(r8), intent(in) :: tfld(:,:)              ! temperature (K)
@@ -2403,7 +2404,7 @@ do_lphase2_conditional: &
     real(r8), intent(in) :: vmr0(:,:,:)       ! initial mixing ratios (before gas-phase chem changes)
     real(r8), intent(inout) :: vmr(:,:,:)         ! mixing ratios ( vmr )
     type(physics_buffer_desc), pointer :: pbuf(:)
-    
+
     ! local vars 
     
     integer :: n, m
@@ -2591,6 +2592,7 @@ do_lphase2_conditional: &
             loffset,   delt,                         &
             latndx,    lonndx,                       &
             tfld,      pmid,    pdel,                &
+            troplev,                                 & !hybrown
             zm,        pblh,                         &
             qh2o,      cldfr,                        &
             vmr,                vmrcw,               &

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -107,6 +107,7 @@ module aero_model
   logical :: drydep_lq(pcnst)
   logical :: wetdep_lq(pcnst)
 
+  logical :: strat_accum_coarse_rename = .false. !hybrown
 
 contains
   
@@ -130,7 +131,7 @@ contains
     character(len=16) :: aer_drydep_list(pcnst) = ' '
 
     namelist /aerosol_nl/ aer_wetdep_list, aer_drydep_list, sol_facti_cloud_borne, seasalt_emis_scale, sscav_tuning, &
-       sol_factb_interstitial, sol_factic_interstitial
+       sol_factb_interstitial, sol_factic_interstitial, strat_accum_coarse_rename !hybrown
 
     !-----------------------------------------------------------------------------
 
@@ -159,6 +160,7 @@ contains
     call mpibcast(sol_factic_interstitial, 1,                       mpir8,   0, mpicom)
     call mpibcast(sscav_tuning,          1,                         mpilog,  0, mpicom)
     call mpibcast(seasalt_emis_scale, 1, mpir8,   0, mpicom)
+    call mpibcast(strat_accum_coarse_rename, 1,                     mpilog,  0, mpicom) !hybrown
 #endif
 
     wetdep_list = aer_wetdep_list
@@ -354,7 +356,7 @@ contains
     endif
     call rad_cnst_get_info(0, nmodes=nmodes)
 
-    call modal_aero_initialize(pbuf2d, imozart, species_class) 
+    call modal_aero_initialize(pbuf2d, imozart, species_class, strat_accum_coarse_rename) !hybrown
     call modal_aero_bcscavcoef_init()
     call mam_prevap_resusp_init( ) ! REASTER 08/04/2015
 

--- a/components/eam/src/chemistry/modal_aero/aero_model.F90
+++ b/components/eam/src/chemistry/modal_aero/aero_model.F90
@@ -107,7 +107,7 @@ module aero_model
   logical :: drydep_lq(pcnst)
   logical :: wetdep_lq(pcnst)
 
-  logical :: strat_accum_coarse_rename = .false. !hybrown
+  !logical :: strat_accum_coarse_rename = .false. !hybrown
 
 contains
   
@@ -131,7 +131,7 @@ contains
     character(len=16) :: aer_drydep_list(pcnst) = ' '
 
     namelist /aerosol_nl/ aer_wetdep_list, aer_drydep_list, sol_facti_cloud_borne, seasalt_emis_scale, sscav_tuning, &
-       sol_factb_interstitial, sol_factic_interstitial, strat_accum_coarse_rename !hybrown
+       sol_factb_interstitial, sol_factic_interstitial !, strat_accum_coarse_rename !hybrown
 
     !-----------------------------------------------------------------------------
 
@@ -160,7 +160,7 @@ contains
     call mpibcast(sol_factic_interstitial, 1,                       mpir8,   0, mpicom)
     call mpibcast(sscav_tuning,          1,                         mpilog,  0, mpicom)
     call mpibcast(seasalt_emis_scale, 1, mpir8,   0, mpicom)
-    call mpibcast(strat_accum_coarse_rename, 1,                     mpilog,  0, mpicom) !hybrown
+    !call mpibcast(strat_accum_coarse_rename, 1,                     mpilog,  0, mpicom) !hybrown
 #endif
 
     wetdep_list = aer_wetdep_list
@@ -356,7 +356,7 @@ contains
     endif
     call rad_cnst_get_info(0, nmodes=nmodes)
 
-    call modal_aero_initialize(pbuf2d, imozart, species_class, strat_accum_coarse_rename) !hybrown
+    call modal_aero_initialize(pbuf2d, imozart, species_class) !, strat_accum_coarse_rename) !hybrown
     call modal_aero_bcscavcoef_init()
     call mam_prevap_resusp_init( ) ! REASTER 08/04/2015
 

--- a/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
@@ -229,6 +229,9 @@
 !hybrown following is used to turn on stratospheric renaming for accumulation to coarse mode aerosol. 
 ! Included to represent rapid growth of sulfate aerosol following volcanic eruption
   logical :: strat_accum_coarse_rename = .false.
+#if ( defined CLDERA_STRAT_VOLC )
+  logical :: strat_accum_coarse_rename = .true.
+#endif
 
 ! !DESCRIPTION: This module implements ...
 !
@@ -1803,6 +1806,7 @@ do_rename_if_block30: &
 
       mtoo_renamexf(:) = 0
       mtoo_renamexf(nait) = nacc
+      write(iulog,*)'hybrown,modal_aero_amicphys, strat_accum_coarse_rename = ',strat_accum_coarse_rename
       if ( strat_accum_coarse_rename ) then
          mtoo_renamexf(nacc) = ncrs !hybrown
       end if
@@ -2235,7 +2239,6 @@ do_rename_if_block30: &
       if ( strat_accum_coarse_rename ) then
          mtoo_renamexf(nacc) = ncrs !hybrown
       end if
-
       qnum_sv1 = qnum_cur
       qaer_sv1 = qaer_cur
 
@@ -5143,7 +5146,7 @@ agepair_loop1: &
 
 !--------------------------------------------------------------------------------
 !--------------------------------------------------------------------------------
-      subroutine modal_aero_amicphys_init( imozart, species_class,n_so4_monolayers_pcage_in, strat_accum_coarse_rename_in) !hybrown
+      subroutine modal_aero_amicphys_init( imozart, species_class,n_so4_monolayers_pcage_in) !, strat_accum_coarse_rename_in) !hybrown
 
 !-----------------------------------------------------------------------
 !
@@ -5202,9 +5205,11 @@ implicit none
    character(128)                 :: msg, fmtaa
    character(2)                   :: tmpch2
 
-   logical, optional, intent(in) :: strat_accum_coarse_rename_in !hybrown
+!   logical, optional, intent(in) :: strat_accum_coarse_rename_in !hybrown
    !-----------------------------------------------------------------------
  
+write(iulog,*)'hybrown, modal_aero_amicphys_init, strat_accum_coarse_rename = ',strat_accum_coarse_rename
+
 !namelist variables
 n_so4_monolayers_pcage  = n_so4_monolayers_pcage_in
 dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
@@ -5557,9 +5562,9 @@ dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
       nufi = modeptr_ufine
 
 !++ hybrown, these lines turn on (ncrs>0) or off (ncrs=0) acc->crs renaming in stratosphere
-      if (present(strat_accum_coarse_rename_in)) then
-         strat_accum_coarse_rename = strat_accum_coarse_rename_in
-      endif
+!#if ( defined CLDERA_STRAT_VOLC )
+!         strat_accum_coarse_rename = .true.
+!#endif
       if (strat_accum_coarse_rename) then
          ncrs = modeptr_coarse
       endif
@@ -5954,6 +5959,10 @@ implicit none
 !++hybrown
       if (strat_accum_coarse_rename) then 
          nc = modeptr_coarse !for coarse mode renaming
+      else
+         !initialize coarse-mode variables
+         nc = 0
+         lmzc = 0
       end if
 !--hybrown
       if (na > 0 .and. nb > 0) then !hybrown

--- a/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
@@ -171,7 +171,7 @@
   integer :: lmapcc_all(gas_pcnst)
   integer, parameter :: lmapcc_val_gas = 1, lmapcc_val_aer = 2, lmapcc_val_num = 3
   integer :: ngas, naer
-  integer :: nacc, nait, npca, nufi, ncrs, nmacc, nmait !hybrown, added ncrs
+  integer :: nacc, nait, npca, nufi, ncrs, nmacc, nmait
 
   integer :: n_agepair, n_coagpair
   integer :: modefrm_agepair(max_agepair), modetoo_agepair(max_agepair)
@@ -226,8 +226,8 @@
   real(r8) :: specdens2_amode(ntot_aspectype,ntot_amode)
   real(r8) :: spechygro2(ntot_aspectype,ntot_amode)
 
-!hybrown following is used to turn on stratospheric renaming for accumulation to coarse mode aerosol. 
-! Included to represent rapid growth of sulfate aerosol following volcanic eruption
+!following is used to turn on stratospheric renaming for accumulation to coarse mode aerosol. 
+!included to represent rapid growth of sulfate aerosol following volcanic eruption
 #if ( defined CLDERA_STRAT_VOLC )
   logical :: strat_accum_coarse_rename = .true.
 #else
@@ -262,7 +262,7 @@ subroutine modal_aero_amicphys_intr(                             &
                         loffset,  deltat,                        &
                         latndx,   lonndx,                        &
                         t,        pmid,     pdel,                &
-                        troplev,                                 & !hybrown
+                        troplev,                                 &
                         zm,       pblh,                          &
                         qv,       cld,                           &
                         q,                  qqcw,                &
@@ -309,7 +309,7 @@ implicit none
 
    real(r8), intent(in)    :: deltat               ! time step (s)
 
-   integer, intent(in)    :: troplev(pcols)       ! hybrown, tropopause level
+   integer, intent(in)    :: troplev(pcols)       ! tropopause level
 
    real(r8), intent(inout) :: q(ncol,pver,pcnstxx) ! current tracer mixing ratios (TMRs)
                                                    ! these values are updated (so out /= in)
@@ -912,7 +912,7 @@ main_i_loop: &
          nsubarea,  ncldy_subarea,                &
          iscldy_subarea,      afracsub,           &
          t(i,k),   pmid(i,k), pdel(i,k),          &
-         troplev(i),                              & !hybrown
+         troplev(i),                              &
          zm(i,k),  pblh(i),   relhumsub,          &
          dgn_a,    dgn_awet,  wetdens,            &
          qsub1,                                   &
@@ -1139,7 +1139,7 @@ main_i_loop: &
          nsubarea,  ncldy_subarea,                &
          iscldy_subarea,     afracsub,            &
          temp,     pmid,     pdel,                &
-         troplev,                                 & !hybrown
+         troplev,                                 &
          zmid,     pblh,     relhumsub,           &
          dgn_a,    dgn_awet, wetdens,             &
          qsub1,                                   &
@@ -1168,7 +1168,7 @@ main_i_loop: &
       real(r8), intent(in)    :: deltat                ! time step (s)
       real(r8), intent(in)    :: afracsub(maxsubarea)   ! sub-area fractional area (0-1)
 
-      integer, intent(in)    :: troplev               ! hybrown, tropopause index
+      integer, intent(in)    :: troplev               ! tropopause index
 
       real(r8), intent(in)    :: temp                  ! temperature at model levels (K)
       real(r8), intent(in)    :: pmid                  ! pressure at layer center (Pa)
@@ -1350,7 +1350,7 @@ main_jsub_loop: &
          jsub,                   nsubarea,           &
          iscldy_subarea(jsub),   afracsub(jsub),     &
          temp,       pmid,       pdel,               &
-         troplev,                                    & !hybrown
+         troplev,                                    &
          zmid,       pblh,       relhumsub(jsub),    &
          dgn_a,      dgn_awet,   wetdens,            &
          qgas1,      qgas3,      qgas4,              &
@@ -1377,7 +1377,7 @@ main_jsub_loop: &
          jsub,                   nsubarea,           &
          iscldy_subarea(jsub),   afracsub(jsub),     &
          temp,       pmid,       pdel,               &
-         troplev,                                    & !hybrown
+         troplev,                                    &
          zmid,       pblh,       relhumsub(jsub),    &
          dgn_a,      dgn_awet,   wetdens,            &
          qgas1,      qgas3,      qgas4,              &
@@ -1458,7 +1458,7 @@ main_jsub_loop: &
          jsub,                   nsubarea,           &
          iscldy_subarea,         afracsub,           &
          temp,       pmid,       pdel,               &
-         troplev,                                    & !hybrown
+         troplev,                                    &
          zmid,       pblh,       relhum,             &
          dgn_a,      dgn_awet,   wetdens,            &
          qgas1,      qgas3,      qgas4,              &
@@ -1505,7 +1505,7 @@ main_jsub_loop: &
       real(r8), intent(in)    :: afracsub              ! fractional area of sub-area (0-1)
       real(r8), intent(in)    :: deltat                ! time step (s)
 
-      integer, intent(in)    :: troplev               ! !hybrown, tropopause level index
+      integer, intent(in)    :: troplev               ! tropopause level index
 
       real(r8), intent(in)    :: temp                  ! temperature at model levels (K)
       real(r8), intent(in)    :: pmid                  ! pressure at layer center (Pa)
@@ -1806,7 +1806,7 @@ do_rename_if_block30: &
       mtoo_renamexf(:) = 0
       mtoo_renamexf(nait) = nacc
       if ( strat_accum_coarse_rename ) then
-         mtoo_renamexf(nacc) = ncrs !hybrown
+         mtoo_renamexf(nacc) = ncrs
       end if
 
 ! qaer_delsub_grow4rnam   = change in qaer from cloud chemistry and gas condensation
@@ -1822,7 +1822,7 @@ do_rename_if_block30: &
       call mam_rename_1subarea(                                      &
          nstep,             lchnk,                                   &
          i,                 k,                jsub,                  &
-         troplev,                                                    & !hybrown
+         troplev,                                                    &
          latndx,            lonndx,           lund,                  &
          iscldy_subarea,                                             &
          mtoo_renamexf,                                              &
@@ -1926,7 +1926,7 @@ do_rename_if_block30: &
          jsub,                   nsubarea,           &
          iscldy_subarea,         afracsub,           &
          temp,       pmid,       pdel,               &
-         troplev,                                    & !hybrown
+         troplev,                                    &
          zmid,       pblh,       relhum,             &
          dgn_a,      dgn_awet,   wetdens,            &
          qgas1,      qgas3,      qgas4,              &
@@ -1964,7 +1964,7 @@ do_rename_if_block30: &
       real(r8), intent(in)    :: afracsub              ! fractional area of sub-area (0-1)
       real(r8), intent(in)    :: deltat                ! time step (s)
 
-      integer, intent(in)    :: troplev               ! hybrown, tropopause level index
+      integer, intent(in)    :: troplev               ! tropopause level index
 
       real(r8), intent(in)    :: temp                  ! temperature at model levels (K)
       real(r8), intent(in)    :: pmid                  ! pressure at layer center (Pa)
@@ -2234,7 +2234,7 @@ do_rename_if_block30: &
       mtoo_renamexf(:) = 0
       mtoo_renamexf(nait) = nacc
       if ( strat_accum_coarse_rename ) then
-         mtoo_renamexf(nacc) = ncrs !hybrown
+         mtoo_renamexf(nacc) = ncrs 
       end if
       qnum_sv1 = qnum_cur
       qaer_sv1 = qaer_cur
@@ -3613,7 +3613,7 @@ time_loop: &
       subroutine mam_rename_1subarea(                               &
          nstep,             lchnk,                                  &
          i,                 k,                jsub,                 &
-         troplev,                                                   & !hybrown
+         troplev,                                                   &
          latndx,            lonndx,           lund,                 &
          iscldy_subarea,                                            &
          mtoo_renamexf,                                             &
@@ -3640,7 +3640,7 @@ time_loop: &
       integer,  intent(in)    :: mtoo_renamexf(max_mode)
       integer,  intent(in)    :: n_mode                ! current number of modes (including temporary)
 
-      integer,  intent(in)    :: troplev               ! hybrown, tropopause level index
+      integer,  intent(in)    :: troplev               ! tropopause level index
 
       real(r8), intent(inout), dimension( 1:max_mode ) :: &
          qnum_cur
@@ -3706,11 +3706,10 @@ time_loop: &
       real(r8) :: xferfrac_vol, xferfrac_num, xferfrac_max
       real(r8) :: yn_tail, yv_tail
 
-      !++hybrown, added to emulate CESM2 WACCM renaming code, which hardcodes
+      !added to emulate CESM2 WACCM renaming code, which hardcodes
       !coarse mode upper and lower bounds for renaming transfer 
       real(r8) :: dp_xferall_thresh(ntot_amode)
       real(r8) :: dp_xfernone_thresh(ntot_amode)
-      !--hybrown
 
       xferfrac_max = 1.0_r8 - 10.0_r8*epsilon(1.0_r8)   ! 1-eps
 
@@ -3741,7 +3740,6 @@ time_loop: &
          dp_cut(mfrm) = sqrt(   &
             dgnum_aer(mfrm)*exp(1.5*(alnsg_aer(mfrm)**2)) *   &
             dgnum_aer(mtoo)*exp(1.5*(alnsg_aer(mtoo)**2)) )
-         !++hybrown
          dp_xferall_thresh(mfrm) = dgnum_aer(mtoo)
          dp_xfernone_thresh(mfrm) = dgnum_aer(mfrm)
 
@@ -3750,7 +3748,6 @@ time_loop: &
             dp_xfernone_thresh(mfrm) = 1.6e-7_r8
             dp_xferall_thresh(mfrm)  = 4.7e-7_r8
          end if
-         !--hybrown
          lndp_cut(mfrm) = log( dp_cut(mfrm) )
          dp_belowcut(mfrm) = 0.99*dp_cut(mfrm)
       end do
@@ -3793,7 +3790,7 @@ mainloop1_ipair:  do n = 1, ntot_amode
       mfrm = n
       mtoo = mtoo_renamexf(n)
       if (mtoo <= 0) cycle mainloop1_ipair
-      if (mtoo == ncrs .and. k >= troplev) cycle mainloop1_ipair !hybrown, only rename accum-coarse in stratosphere. Also only activated if ncrs>0
+      if (mtoo == ncrs .and. k >= troplev) cycle mainloop1_ipair !only rename accum-coarse in stratosphere. Also only activated if ncrs>0
 
 !   dryvol_t_old is the old total (a+c) dry-volume for the "from" mode 
 !      in m^3-AP/kmol-air
@@ -3825,7 +3822,7 @@ mainloop1_ipair:  do n = 1, ntot_amode
 
 !   no renaming if dgnum < "base" dgnum, 
       dgn_t_new = (dryvol_t_new/(num_t_oldbnd*factoraa(mfrm)))**onethird
-      if (dgn_t_new .le. dp_xfernone_thresh(mfrm)) cycle mainloop1_ipair  !hybrown
+      if (dgn_t_new .le. dp_xfernone_thresh(mfrm)) cycle mainloop1_ipair 
 
 !   compute new fraction of number and mass in the tail (dp > dp_cut)
       lndgn_new = log( dgn_t_new )
@@ -3847,11 +3844,10 @@ mainloop1_ipair:  do n = 1, ntot_amode
             dryvol_t_old = dryvol_t_old * (dp_belowcut(mfrm)/dgn_t_old)**3
             dgn_t_old = dp_belowcut(mfrm)
          end if
-!++hybrown, insert xferall_thresh variable condional for acc->crs and ait->acc
+            ! insert xferall_thresh variable condional for acc->crs and ait->acc
             if ( dgn_t_new .lt. dp_xferall_thresh(mfrm) ) then
                if ((dryvol_t_new-dryvol_t_old) .le. 1.0e-6_r8*dryvol_t_oldbnd) cycle mainloop1_ipair
             end if
-!--hybrown
       else if (dgn_t_new .ge. dp_cut(mfrm)) then
 !         if dgn_t_new exceeds dp_cut, use the minimum of dgn_t_old and 
 !         dp_belowcut to guarantee some transfer
@@ -3866,13 +3862,12 @@ mainloop1_ipair:  do n = 1, ntot_amode
 
 !   transfer fraction is difference between new and old tail-fractions
 !   transfer fraction for number cannot exceed that of mass
-!++hybrown, use xferall specification for acc->crs and ait->acc to emulate WACCM treatment
+         ! use xferall specification for acc->crs and ait->acc to emulate WACCM treatment
          if (dgn_t_new .ge. dp_xferall_thresh(mfrm)) then
             tmpa = dryvol_t_new
          else
             tmpa = tailfr_volnew*dryvol_t_new - tailfr_volold*dryvol_t_old
          end if
-!--hybrown
       if (tmpa .le. 0.0_r8) cycle mainloop1_ipair
 
       xferfrac_vol = min( tmpa, dryvol_t_new )/dryvol_t_new
@@ -5170,7 +5165,7 @@ use modal_aero_data, only : &
     cnst_name_cw, &
     dgnum_amode, dgnumlo_amode, dgnumhi_amode, &
     lmassptr_amode, lmassptrcw_amode, &
-    modeptr_accum, modeptr_aitken, modeptr_pcarbon, modeptr_ufine, modeptr_coarse, & !hybrown, added modeptr_coarse
+    modeptr_accum, modeptr_aitken, modeptr_pcarbon, modeptr_ufine, modeptr_coarse, &
     modeptr_maccum, modeptr_maitken, &
     nspec_amode, &
     numptr_amode, numptrcw_amode, sigmag_amode
@@ -5555,11 +5550,10 @@ dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
       npca = modeptr_pcarbon
       nufi = modeptr_ufine
 
-!++ hybrown, these lines turn on (ncrs>0) or off (ncrs=0) acc->crs renaming in stratosphere
+      ! these lines turn on (ncrs>0) or off (ncrs=0) acc->crs renaming in stratosphere
       if (strat_accum_coarse_rename) then
          ncrs = modeptr_coarse
       endif
-!-- hybrown
 
 #if ( defined MODAL_AERO_9MODE )
       nmacc = modeptr_maccum
@@ -5835,7 +5829,7 @@ use phys_control,only  :  phys_getopts
 
 use modal_aero_data, only : &
     cnst_name_cw, &
-    modeptr_accum, modeptr_aitken, modeptr_pcarbon, modeptr_ufine, modeptr_coarse !hybrown, added modeptr_coarse
+    modeptr_accum, modeptr_aitken, modeptr_pcarbon, modeptr_ufine, modeptr_coarse
 !use modal_aero_rename
 
 implicit none
@@ -5947,7 +5941,6 @@ implicit none
 ! renaming during gas-->aer condensation or cloud chemistry
       na = modeptr_aitken
       nb = modeptr_accum
-!++hybrown
       if (strat_accum_coarse_rename) then 
          nc = modeptr_coarse !for coarse mode renaming
       else
@@ -5955,8 +5948,7 @@ implicit none
          nc = 0
          lmzc = 0
       end if
-!--hybrown
-      if (na > 0 .and. nb > 0) then !hybrown
+      if (na > 0 .and. nb > 0) then
          lmza = lmap_num(na)
          lmzb = lmap_num(nb)
          do_q_coltendaa(lmza,iqtend_rnam) = .true.
@@ -5965,9 +5957,8 @@ implicit none
          lmzb = lmap_numcw(nb)
          do_qqcw_coltendaa(lmza,iqqcwtend_rnam) = .true.
          do_qqcw_coltendaa(lmzb,iqqcwtend_rnam) = .true.
-!++hybrown
-         if (nc > 0) then !hybrown, for coarse mode renaming
-            lmzc = lmap_num(nc) !hybrown
+         if (nc > 0) then ! for coarse mode renaming
+            lmzc = lmap_num(nc)
             do_q_coltendaa(lmzc,iqtend_rnam) = .true.
             lmzc = lmap_numcw(nc)
             do_qqcw_coltendaa(lmzc,iqqcwtend_rnam) = .true.
@@ -5975,26 +5966,23 @@ implicit none
          do iaer = 1, naer
             lmza = lmap_aer(iaer,na)
             lmzb = lmap_aer(iaer,nb)
-!++hybrown
             if (nc > 0) then
-               lmzc = lmap_aer(iaer,nc) !hybrown
+               lmzc = lmap_aer(iaer,nc)
             end if
             if (lmza > 0) then
                do_q_coltendaa(lmza,iqtend_rnam) = .true.
                if (lmzb > 0) do_q_coltendaa(lmzb,iqtend_rnam) = .true.
-               if (lmzc > 0) do_q_coltendaa(lmzc,iqtend_rnam) = .true. !hybrown
+               if (lmzc > 0) do_q_coltendaa(lmzc,iqtend_rnam) = .true.
             end if
             lmza = lmap_aercw(iaer,na)
             lmzb = lmap_aercw(iaer,nb)
-!++hybrown
             if (nc > 0) then
                lmzc = lmap_aercw(iaer,nc)
             end if
-!--hybrown
             if (lmza > 0) then
                do_qqcw_coltendaa(lmza,iqqcwtend_rnam) = .true.
                if (lmzb > 0) do_qqcw_coltendaa(lmzb,iqqcwtend_rnam) = .true.
-               if (lmzc > 0) do_qqcw_coltendaa(lmzc,iqqcwtend_rnam)  =.true. !hybrown
+               if (lmzc > 0) do_qqcw_coltendaa(lmzc,iqqcwtend_rnam)  =.true.
             end if
          end do ! iaer
       end if ! (na > 0 .and. nb > 0)

--- a/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
@@ -171,7 +171,7 @@
   integer :: lmapcc_all(gas_pcnst)
   integer, parameter :: lmapcc_val_gas = 1, lmapcc_val_aer = 2, lmapcc_val_num = 3
   integer :: ngas, naer
-  integer :: nacc, nait, npca, nufi, nmacc, nmait
+  integer :: nacc, nait, npca, nufi, ncrs, nmacc, nmait !hybrown, added ncrs
 
   integer :: n_agepair, n_coagpair
   integer :: modefrm_agepair(max_agepair), modetoo_agepair(max_agepair)
@@ -255,6 +255,7 @@ subroutine modal_aero_amicphys_intr(                             &
                         loffset,  deltat,                        &
                         latndx,   lonndx,                        &
                         t,        pmid,     pdel,                &
+                        troplev,                                 & !hybrown
                         zm,       pblh,                          &
                         qv,       cld,                           &
                         q,                  qqcw,                &
@@ -300,6 +301,8 @@ implicit none
 #endif
 
    real(r8), intent(in)    :: deltat               ! time step (s)
+
+   integer, intent(in)    :: troplev(pcols)       ! hybrown, tropopause level
 
    real(r8), intent(inout) :: q(ncol,pver,pcnstxx) ! current tracer mixing ratios (TMRs)
                                                    ! these values are updated (so out /= in)
@@ -902,6 +905,7 @@ main_i_loop: &
          nsubarea,  ncldy_subarea,                &
          iscldy_subarea,      afracsub,           &
          t(i,k),   pmid(i,k), pdel(i,k),          &
+         troplev(i),                              & !hybrown
          zm(i,k),  pblh(i),   relhumsub,          &
          dgn_a,    dgn_awet,  wetdens,            &
          qsub1,                                   &
@@ -1128,6 +1132,7 @@ main_i_loop: &
          nsubarea,  ncldy_subarea,                &
          iscldy_subarea,     afracsub,            &
          temp,     pmid,     pdel,                &
+         troplev,                                 & !hybrown
          zmid,     pblh,     relhumsub,           &
          dgn_a,    dgn_awet, wetdens,             &
          qsub1,                                   &
@@ -1155,6 +1160,8 @@ main_i_loop: &
 
       real(r8), intent(in)    :: deltat                ! time step (s)
       real(r8), intent(in)    :: afracsub(maxsubarea)   ! sub-area fractional area (0-1)
+
+      integer, intent(in)    :: troplev               ! hybrown, tropopause index
 
       real(r8), intent(in)    :: temp                  ! temperature at model levels (K)
       real(r8), intent(in)    :: pmid                  ! pressure at layer center (Pa)
@@ -1336,6 +1343,7 @@ main_jsub_loop: &
          jsub,                   nsubarea,           &
          iscldy_subarea(jsub),   afracsub(jsub),     &
          temp,       pmid,       pdel,               &
+         troplev,                                    & !hybrown
          zmid,       pblh,       relhumsub(jsub),    &
          dgn_a,      dgn_awet,   wetdens,            &
          qgas1,      qgas3,      qgas4,              &
@@ -1362,6 +1370,7 @@ main_jsub_loop: &
          jsub,                   nsubarea,           &
          iscldy_subarea(jsub),   afracsub(jsub),     &
          temp,       pmid,       pdel,               &
+         troplev,                                    & !hybrown
          zmid,       pblh,       relhumsub(jsub),    &
          dgn_a,      dgn_awet,   wetdens,            &
          qgas1,      qgas3,      qgas4,              &
@@ -1442,6 +1451,7 @@ main_jsub_loop: &
          jsub,                   nsubarea,           &
          iscldy_subarea,         afracsub,           &
          temp,       pmid,       pdel,               &
+         troplev,                                    & !hybrown
          zmid,       pblh,       relhum,             &
          dgn_a,      dgn_awet,   wetdens,            &
          qgas1,      qgas3,      qgas4,              &
@@ -1487,6 +1497,8 @@ main_jsub_loop: &
 
       real(r8), intent(in)    :: afracsub              ! fractional area of sub-area (0-1)
       real(r8), intent(in)    :: deltat                ! time step (s)
+
+      integer, intent(in)    :: troplev               ! !hybrown, tropopause level index
 
       real(r8), intent(in)    :: temp                  ! temperature at model levels (K)
       real(r8), intent(in)    :: pmid                  ! pressure at layer center (Pa)
@@ -1788,6 +1800,7 @@ do_rename_if_block30: &
 
       mtoo_renamexf(:) = 0
       mtoo_renamexf(nait) = nacc
+      mtoo_renamexf(nacc) = ncrs !hybrown
 
 ! qaer_delsub_grow4rnam   = change in qaer from cloud chemistry and gas condensation
 ! qaercw_delsub_grow4rnam = change in qaercw from cloud chemistry
@@ -1802,6 +1815,7 @@ do_rename_if_block30: &
       call mam_rename_1subarea(                                      &
          nstep,             lchnk,                                   &
          i,                 k,                jsub,                  &
+         troplev,                                                    & !hybrown
          latndx,            lonndx,           lund,                  &
          iscldy_subarea,                                             &
          mtoo_renamexf,                                              &
@@ -1905,6 +1919,7 @@ do_rename_if_block30: &
          jsub,                   nsubarea,           &
          iscldy_subarea,         afracsub,           &
          temp,       pmid,       pdel,               &
+         troplev,                                    & !hybrown
          zmid,       pblh,       relhum,             &
          dgn_a,      dgn_awet,   wetdens,            &
          qgas1,      qgas3,      qgas4,              &
@@ -1941,6 +1956,8 @@ do_rename_if_block30: &
 
       real(r8), intent(in)    :: afracsub              ! fractional area of sub-area (0-1)
       real(r8), intent(in)    :: deltat                ! time step (s)
+
+      integer, intent(in)    :: troplev               ! hybrown, tropopause level index
 
       real(r8), intent(in)    :: temp                  ! temperature at model levels (K)
       real(r8), intent(in)    :: pmid                  ! pressure at layer center (Pa)
@@ -2210,6 +2227,7 @@ do_rename_if_block30: &
 
       mtoo_renamexf(:) = 0
       mtoo_renamexf(nait) = nacc
+      mtoo_renamexf(nacc) = ncrs !hybrown
 
       qnum_sv1 = qnum_cur
       qaer_sv1 = qaer_cur
@@ -2217,6 +2235,7 @@ do_rename_if_block30: &
       call mam_rename_1subarea(                                    &
          nstep,             lchnk,                                 &
          i,                 k,                jsub,                &
+         troplev,                                                  &
          latndx,            lonndx,           lund,                &
          iscldy_subarea,                                           &
          mtoo_renamexf,                                            &
@@ -3587,6 +3606,7 @@ time_loop: &
       subroutine mam_rename_1subarea(                               &
          nstep,             lchnk,                                  &
          i,                 k,                jsub,                 &
+         troplev,                                                   & !hybrown
          latndx,            lonndx,           lund,                 &
          iscldy_subarea,                                            &
          mtoo_renamexf,                                             &
@@ -3612,6 +3632,8 @@ time_loop: &
       integer,  intent(in)    :: lund                  ! logical unit for diagnostic output
       integer,  intent(in)    :: mtoo_renamexf(max_mode)
       integer,  intent(in)    :: n_mode                ! current number of modes (including temporary)
+
+      integer,  intent(in)    :: troplev               ! hybrown, tropopause level index
 
       real(r8), intent(inout), dimension( 1:max_mode ) :: &
          qnum_cur
@@ -3749,6 +3771,7 @@ mainloop1_ipair:  do n = 1, ntot_amode
       mfrm = n
       mtoo = mtoo_renamexf(n)
       if (mtoo <= 0) cycle mainloop1_ipair
+      if ( mtoo == ncrs .and. k >= troplev ) cycle mainloop1_ipair !hybrown, only rename accum-coarse in stratosphere
 
 !   dryvol_t_old is the old total (a+c) dry-volume for the "from" mode 
 !      in m^3-AP/kmol-air
@@ -5115,7 +5138,7 @@ use modal_aero_data, only : &
     cnst_name_cw, &
     dgnum_amode, dgnumlo_amode, dgnumhi_amode, &
     lmassptr_amode, lmassptrcw_amode, &
-    modeptr_accum, modeptr_aitken, modeptr_pcarbon, modeptr_ufine, &
+    modeptr_accum, modeptr_aitken, modeptr_pcarbon, modeptr_ufine, modeptr_coarse, & !hybrown, added modeptr_coarse
     modeptr_maccum, modeptr_maitken, &
     nspec_amode, &
     numptr_amode, numptrcw_amode, sigmag_amode
@@ -5498,6 +5521,7 @@ dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
       nait = modeptr_aitken
       npca = modeptr_pcarbon
       nufi = modeptr_ufine
+      ncrs = modeptr_coarse !hybrown
 #if ( defined MODAL_AERO_9MODE )
       nmacc = modeptr_maccum
       nmait = modeptr_maitken
@@ -5772,7 +5796,7 @@ use phys_control,only  :  phys_getopts
 
 use modal_aero_data, only : &
     cnst_name_cw, &
-    modeptr_accum, modeptr_aitken, modeptr_pcarbon, modeptr_ufine
+    modeptr_accum, modeptr_aitken, modeptr_pcarbon, modeptr_ufine, modeptr_coarse !hybrown, added modeptr_coarse
 !use modal_aero_rename
 
 implicit none
@@ -5884,27 +5908,36 @@ implicit none
 ! renaming during gas-->aer condensation or cloud chemistry
       na = modeptr_aitken
       nb = modeptr_accum
-      if (na > 0 .and. nb > 0) then
+      nc = modeptr_coarse !hybrown, coarse mode renaming
+      if (na > 0 .and. nb > 0 .and. nc > 0) then !hybrown, added nc to include coarse mode renaming
          lmza = lmap_num(na)
          lmzb = lmap_num(nb)
+         lmzc = lmap_num(nc) !hybrown
          do_q_coltendaa(lmza,iqtend_rnam) = .true.
          do_q_coltendaa(lmzb,iqtend_rnam) = .true.
+         do_q_coltendaa(lmzc,iqtend_rnam) = .true. !hybrown
          lmza = lmap_numcw(na)
          lmzb = lmap_numcw(nb)
+         lmzc = lmap_numcw(nc) !hybrown
          do_qqcw_coltendaa(lmza,iqqcwtend_rnam) = .true.
          do_qqcw_coltendaa(lmzb,iqqcwtend_rnam) = .true.
+         do_qqcw_coltendaa(lmzc,iqqcwtend_rnam) = .true. !hybrown
          do iaer = 1, naer
             lmza = lmap_aer(iaer,na)
             lmzb = lmap_aer(iaer,nb)
+            lmzc = lmap_aer(iaer,nc) !hybrown
             if (lmza > 0) then
                do_q_coltendaa(lmza,iqtend_rnam) = .true.
                if (lmzb > 0) do_q_coltendaa(lmzb,iqtend_rnam) = .true.
+               if (lmzc > 0) do_q_coltendaa(lmzc,iqtend_rnam) = .true. !hybrown
             end if
             lmza = lmap_aercw(iaer,na)
             lmzb = lmap_aercw(iaer,nb)
+            lmzc = lmap_aercw(iaer,nc) !hybrown
             if (lmza > 0) then
                do_qqcw_coltendaa(lmza,iqqcwtend_rnam) = .true.
                if (lmzb > 0) do_qqcw_coltendaa(lmzb,iqqcwtend_rnam) = .true.
+               if (lmzc > 0) do_qqcw_coltendaa(lmzc,iqqcwtend_rnam)  =.true. !hybrown
             end if
          end do ! iaer
       end if ! (na > 0 .and. nb > 0)

--- a/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
@@ -228,9 +228,10 @@
 
 !hybrown following is used to turn on stratospheric renaming for accumulation to coarse mode aerosol. 
 ! Included to represent rapid growth of sulfate aerosol following volcanic eruption
-  logical :: strat_accum_coarse_rename = .false.
 #if ( defined CLDERA_STRAT_VOLC )
   logical :: strat_accum_coarse_rename = .true.
+#else
+  logical :: strat_accum_coarse_rename = .false.
 #endif
 
 ! !DESCRIPTION: This module implements ...
@@ -1651,8 +1652,6 @@ main_jsub_loop: &
       real(r8) :: uptkaer(max_gas,max_mode)
       real(r8) :: uptkrate_h2so4
 
-
-
 ! air molar density (kmol/m3)
       aircon = pmid/(r_universal*temp)
 
@@ -1806,7 +1805,6 @@ do_rename_if_block30: &
 
       mtoo_renamexf(:) = 0
       mtoo_renamexf(nait) = nacc
-      write(iulog,*)'hybrown,modal_aero_amicphys, strat_accum_coarse_rename = ',strat_accum_coarse_rename
       if ( strat_accum_coarse_rename ) then
          mtoo_renamexf(nacc) = ncrs !hybrown
       end if
@@ -2086,7 +2084,6 @@ do_rename_if_block30: &
       real(r8) :: tmpa, tmpb, tmpc, tmpd, tmpe, tmpf
       real(r8) :: uptkaer(max_gas,max_mode)
       real(r8) :: uptkrate_h2so4
-
 
 
 ! air molar density (kmol/m3)
@@ -5146,7 +5143,7 @@ agepair_loop1: &
 
 !--------------------------------------------------------------------------------
 !--------------------------------------------------------------------------------
-      subroutine modal_aero_amicphys_init( imozart, species_class,n_so4_monolayers_pcage_in) !, strat_accum_coarse_rename_in) !hybrown
+      subroutine modal_aero_amicphys_init( imozart, species_class,n_so4_monolayers_pcage_in)
 
 !-----------------------------------------------------------------------
 !
@@ -5205,11 +5202,8 @@ implicit none
    character(128)                 :: msg, fmtaa
    character(2)                   :: tmpch2
 
-!   logical, optional, intent(in) :: strat_accum_coarse_rename_in !hybrown
    !-----------------------------------------------------------------------
  
-write(iulog,*)'hybrown, modal_aero_amicphys_init, strat_accum_coarse_rename = ',strat_accum_coarse_rename
-
 !namelist variables
 n_so4_monolayers_pcage  = n_so4_monolayers_pcage_in
 dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
@@ -5562,9 +5556,6 @@ dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
       nufi = modeptr_ufine
 
 !++ hybrown, these lines turn on (ncrs>0) or off (ncrs=0) acc->crs renaming in stratosphere
-!#if ( defined CLDERA_STRAT_VOLC )
-!         strat_accum_coarse_rename = .true.
-!#endif
       if (strat_accum_coarse_rename) then
          ncrs = modeptr_coarse
       endif

--- a/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_amicphys.F90
@@ -5551,6 +5551,7 @@ dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10
       nufi = modeptr_ufine
 
       ! these lines turn on (ncrs>0) or off (ncrs=0) acc->crs renaming in stratosphere
+      ncrs = 0
       if (strat_accum_coarse_rename) then
          ncrs = modeptr_coarse
       endif

--- a/components/eam/src/chemistry/modal_aero/modal_aero_initialize_data.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_initialize_data.F90
@@ -370,7 +370,7 @@ contains
 
 
   !==============================================================
-  subroutine modal_aero_initialize(pbuf2d, imozart, species_class, strat_accum_coarse_rename_in) !hybrown
+  subroutine modal_aero_initialize(pbuf2d, imozart, species_class) !, strat_accum_coarse_rename_in) !hybrown
 
        use constituents,          only: pcnst
        use physconst,             only: rhoh2o, mwh2o
@@ -392,7 +392,7 @@ contains
        type(physics_buffer_desc), pointer :: pbuf2d(:,:)
        integer, intent(in) :: imozart  
        integer, intent(inout) :: species_class(:)  
-       logical, intent(in) :: strat_accum_coarse_rename_in !hybrown
+       !logical, intent(in) :: strat_accum_coarse_rename_in !hybrown
        !--------------------------------------------------------------
        ! ... local variables
        !--------------------------------------------------------------
@@ -608,7 +608,7 @@ loop:    do i = icldphy+1, pcnst
        if ( mam_amicphys_optaa > 0 ) then
           call modal_aero_calcsize_init( pbuf2d, species_class )
           call modal_aero_newnuc_init( mam_amicphys_optaa )
-          call modal_aero_amicphys_init( imozart, species_class,n_so4_monolayers_pcage_in, strat_accum_coarse_rename_in ) !hybrown
+          call modal_aero_amicphys_init( imozart, species_class,n_so4_monolayers_pcage_in) !, strat_accum_coarse_rename_in ) !hybrown
        else
           call modal_aero_rename_init
           !   calcsize call must follow rename call

--- a/components/eam/src/chemistry/modal_aero/modal_aero_initialize_data.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_initialize_data.F90
@@ -370,7 +370,7 @@ contains
 
 
   !==============================================================
-  subroutine modal_aero_initialize(pbuf2d, imozart, species_class) !, strat_accum_coarse_rename_in) !hybrown
+  subroutine modal_aero_initialize(pbuf2d, imozart, species_class)
 
        use constituents,          only: pcnst
        use physconst,             only: rhoh2o, mwh2o
@@ -392,7 +392,6 @@ contains
        type(physics_buffer_desc), pointer :: pbuf2d(:,:)
        integer, intent(in) :: imozart  
        integer, intent(inout) :: species_class(:)  
-       !logical, intent(in) :: strat_accum_coarse_rename_in !hybrown
        !--------------------------------------------------------------
        ! ... local variables
        !--------------------------------------------------------------
@@ -608,7 +607,7 @@ loop:    do i = icldphy+1, pcnst
        if ( mam_amicphys_optaa > 0 ) then
           call modal_aero_calcsize_init( pbuf2d, species_class )
           call modal_aero_newnuc_init( mam_amicphys_optaa )
-          call modal_aero_amicphys_init( imozart, species_class,n_so4_monolayers_pcage_in) !, strat_accum_coarse_rename_in ) !hybrown
+          call modal_aero_amicphys_init( imozart, species_class,n_so4_monolayers_pcage_in)
        else
           call modal_aero_rename_init
           !   calcsize call must follow rename call

--- a/components/eam/src/chemistry/modal_aero/modal_aero_initialize_data.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_initialize_data.F90
@@ -370,7 +370,7 @@ contains
 
 
   !==============================================================
-  subroutine modal_aero_initialize(pbuf2d, imozart, species_class) 
+  subroutine modal_aero_initialize(pbuf2d, imozart, species_class, strat_accum_coarse_rename_in) !hybrown
 
        use constituents,          only: pcnst
        use physconst,             only: rhoh2o, mwh2o
@@ -392,6 +392,7 @@ contains
        type(physics_buffer_desc), pointer :: pbuf2d(:,:)
        integer, intent(in) :: imozart  
        integer, intent(inout) :: species_class(:)  
+       logical, intent(in) :: strat_accum_coarse_rename_in !hybrown
        !--------------------------------------------------------------
        ! ... local variables
        !--------------------------------------------------------------
@@ -607,7 +608,7 @@ loop:    do i = icldphy+1, pcnst
        if ( mam_amicphys_optaa > 0 ) then
           call modal_aero_calcsize_init( pbuf2d, species_class )
           call modal_aero_newnuc_init( mam_amicphys_optaa )
-          call modal_aero_amicphys_init( imozart, species_class,n_so4_monolayers_pcage_in )
+          call modal_aero_amicphys_init( imozart, species_class,n_so4_monolayers_pcage_in, strat_accum_coarse_rename_in ) !hybrown
        else
           call modal_aero_rename_init
           !   calcsize call must follow rename call

--- a/components/eam/src/chemistry/modal_aero/modal_aero_rename.F90
+++ b/components/eam/src/chemistry/modal_aero/modal_aero_rename.F90
@@ -510,7 +510,6 @@ mainloop1_ipair:  do ipair = 1, npair_renamexf
       	  lsfrma, lsfrmc, lstooa, lstooc, lunout,   &
       	  mfrm, mtoo, n1, n2, nsamefrm, nsametoo, nspec
 
-
 	lunout = 6
 !
 !   define "from mode" and "to mode" for each tail-xfer pairing

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -792,7 +792,7 @@ contains
 
     call t_startf('aero_model_gasaerexch')
     call aero_model_gasaerexch( imozart-1, ncol, lchnk, delt, latndx, lonndx, reaction_rates, &
-                                tfld, pmid, pdel, mbar, relhum, &
+                                tfld, pmid, pdel, troplev, mbar, relhum, & !hybrown, added troplev
                                 zm,  qh2o, cwat, cldfr, ncldwtr, &
                                 invariants(:,:,indexm), invariants, del_h2so4_gasprod,  &
                                 vmr0, vmr, pbuf )

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -792,7 +792,7 @@ contains
 
     call t_startf('aero_model_gasaerexch')
     call aero_model_gasaerexch( imozart-1, ncol, lchnk, delt, latndx, lonndx, reaction_rates, &
-                                tfld, pmid, pdel, troplev, mbar, relhum, & !hybrown, added troplev
+                                tfld, pmid, pdel, troplev, mbar, relhum, &
                                 zm,  qh2o, cwat, cldfr, ncldwtr, &
                                 invariants(:,:,indexm), invariants, del_h2so4_gasprod,  &
                                 vmr0, vmr, pbuf )


### PR DESCRIPTION
Prognostic stratospheric aerosol modifications with a flag to turn the implementation on/off. This flag (cldera_strat_volc) is turned off by default and can be turned on in the runscript and added to cpp_defs. Without any specification in the runscript, the model runs with the default aerosol treatment.