### PR TITLE
jhollowed/eam/cldera-passive-tracers

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -960,7 +960,7 @@ if ($cfg->get('nadv_tt')) { add_default($nl, 'tracers_flag', 'val'=>'.true.'); }
 if ($cfg->get('age_of_air_trcs')) { add_default($nl, 'aoa_tracers_flag', 'val'=>'.true.'); }
 
 # CLDERA AOA, E90, ST80 tracers
-if ($cfg->get('cldera_clock_trcs')) { add_default($nl,'cldera_clock_tracers_flag','val'=>'.true.');}
+if ($cfg->get('cldera_passive_trcs')) { add_default($nl,'cldera_passive_tracers_flag','val'=>'.true.');}
 
 # CLDERA SAI tracers
 if ($cfg->get('cldera_sai_trcs')) { add_default($nl, 'cldera_sai_tracers_flag', 'val'=>'.true.'); }

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -959,6 +959,9 @@ my $co2_cycle_rad_passive = ($nl->get_value('co2_cycle_rad_passive') =~ /$TRUE/i
 if ($cfg->get('nadv_tt')) { add_default($nl, 'tracers_flag', 'val'=>'.true.'); }
 if ($cfg->get('age_of_air_trcs')) { add_default($nl, 'aoa_tracers_flag', 'val'=>'.true.'); }
 
+# CLDERA AOA, E90, ST80 tracers
+if ($cfg->get('cldera_clock_trcs')) { add_default($nl,'cldera_clock_tracers_flag','val'=>'.true.');}
+
 # CLDERA SAI tracers
 if ($cfg->get('cldera_sai_trcs')) { add_default($nl, 'cldera_sai_tracers_flag', 'val'=>'.true.'); }
 add_default($nl, 'cldera_sai_read_from_ic_file');

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -959,7 +959,7 @@ my $co2_cycle_rad_passive = ($nl->get_value('co2_cycle_rad_passive') =~ /$TRUE/i
 if ($cfg->get('nadv_tt')) { add_default($nl, 'tracers_flag', 'val'=>'.true.'); }
 if ($cfg->get('age_of_air_trcs')) { add_default($nl, 'aoa_tracers_flag', 'val'=>'.true.'); }
 
-# CLDERA AOA, E90, ST80 tracers
+# CLDERA AOA, E90, ST80_25 tracers
 if ($cfg->get('cldera_passive_trcs')) { add_default($nl,'cldera_passive_tracers_flag','val'=>'.true.');}
 
 # CLDERA SAI tracers

--- a/components/eam/bld/config_files/definition.xml
+++ b/components/eam/bld/config_files/definition.xml
@@ -190,6 +190,9 @@ Switch on (off) age of air tracers: 0=off, 1=on.
 <entry id="cldera_sai_trcs" valid_values="0,1" value="0">
 Switch on (off) idealized stratospheric aerosol injection tracers: 0=off, 1=on.
 </entry>
+<entry id="cldera_clock_trcs" valid_values="0,1" value="0">
+Switch on (off) CLDERA aoa, e90, st80 tracers: 0=off, 1=on.
+</entry>
 <entry id="max_n_rad_cnst" value="30">
 Maximum number of constituents that are radiatively active or in any one
 diagnostic list.

--- a/components/eam/bld/config_files/definition.xml
+++ b/components/eam/bld/config_files/definition.xml
@@ -190,7 +190,7 @@ Switch on (off) age of air tracers: 0=off, 1=on.
 <entry id="cldera_sai_trcs" valid_values="0,1" value="0">
 Switch on (off) idealized stratospheric aerosol injection tracers: 0=off, 1=on.
 </entry>
-<entry id="cldera_clock_trcs" valid_values="0,1" value="0">
+<entry id="cldera_passive_trcs" valid_values="0,1" value="0">
 Switch on (off) CLDERA aoa, e90, st80 tracers: 0=off, 1=on.
 </entry>
 <entry id="max_n_rad_cnst" value="30">

--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -285,7 +285,7 @@ OPTIONS
 
      -cldera_profiling  Build EAM with support for CLDERA profiling, linking to cldera-profiling
      -cldera_sai_trcs   Switch on idealized stratospheric aerosol injection tracers. Default: off
-     -cldera_clock_trcs Switch on CLDERA clock tracers. Default: off
+     -cldera_passive_trcs Switch on CLDERA passive tracers. Default: off
 EOF
 }
 
@@ -324,7 +324,7 @@ my %opts = (
 GetOptions(
     "age_of_air_trcs!"          => \$opts{'age_of_air_trcs'},
     "cldera_sai_trcs!"          => \$opts{'cldera_sai_trcs'},
-    "cldera_clock_trcs!"        => \$opts{'cldera_clock_trcs'},
+    "cldera_passive_trcs!"        => \$opts{'cldera_passive_trcs'},
     "aquaplanet"                => \$opts{'aquaplanet'},
     "cache=s"                   => \$opts{'cache'},
     "cachedir=s"                => \$opts{'cachedir'},
@@ -881,12 +881,12 @@ if (defined $opts{'cldera_sai_trcs'}) {
 my $cldera_sai_trcs = $cfg_ref->get('cldera_sai_trcs') ? "ON" : "OFF";
 if ($print>=2) { print "CLDERA SAI tracer package: $cldera_sai_trcs$eol"; }
 
-# Allow user to turn on the cldera clock tracers
-if (defined $opts{'cldera_clock_trcs'}) {
-    $cfg_ref->set('cldera_clock_trcs', $opts{'cldera_clock_trcs'});
+# Allow user to turn on the cldera passive tracers
+if (defined $opts{'cldera_passive_trcs'}) {
+    $cfg_ref->set('cldera_passive_trcs', $opts{'cldera_passive_trcs'});
 }
-my $cldera_clock_trcs = $cfg_ref->get('cldera_clock_trcs') ? "ON" : "OFF";
-if ($print>=2) { print "CLDERA clock tracer package: $cldera_clock_trcs$eol"; }
+my $cldera_passive_trcs = $cfg_ref->get('cldera_passive_trcs') ? "ON" : "OFF";
+if ($print>=2) { print "CLDERA passive tracer package: $cldera_passive_trcs$eol"; }
 
 # waccmx option
 if (defined $opts{'waccmx'}) {
@@ -1499,9 +1499,9 @@ else {
         if ($print>=2) { print "Advected constituents added by the CLDERA SAI tracer package: 5$eol"; }
     }
 
-    if ($cldera_clock_trcs eq "ON") {
+    if ($cldera_passive_trcs eq "ON") {
 	$nadv += 3;
-        if ($print>=2) { print "Advected constituents added by the CLDERA clock tracers package: 4$eol"; }
+        if ($print>=2) { print "Advected constituents added by the CLDERA passive tracers package: 4$eol"; }
     }
 
     $cfg_ref->set('nadv', $nadv);

--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -324,7 +324,7 @@ my %opts = (
 GetOptions(
     "age_of_air_trcs!"          => \$opts{'age_of_air_trcs'},
     "cldera_sai_trcs!"          => \$opts{'cldera_sai_trcs'},
-    "cldera_passive_trcs!"        => \$opts{'cldera_passive_trcs'},
+    "cldera_passive_trcs!"      => \$opts{'cldera_passive_trcs'},
     "aquaplanet"                => \$opts{'aquaplanet'},
     "cache=s"                   => \$opts{'cache'},
     "cachedir=s"                => \$opts{'cachedir'},

--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -112,7 +112,6 @@ OPTIONS
   effect whether running EAM as part of CCSM or running in a EAM standalone mode:
 
      -[no]age_of_air_trcs Switch on [off] age of air tracers. Default: on for waccm_phys, otherwise off
-     -cldera_sai_trcs   Switch on idealized stratospheric aerosol injection tracers. Default: off
      -aquaplanet        Switch on aqua-planet mode w/ SST controlled by data ocean component in CIME
      -rce               Use homogenous conditions for radiative-convective equilibrium (RCE), normally used with aquaplanet
      -chem <name>       Build EAM with specified prognostic chemistry package
@@ -285,6 +284,8 @@ OPTIONS
   Options for CLDERA-E3SM
 
      -cldera_profiling  Build EAM with support for CLDERA profiling, linking to cldera-profiling
+     -cldera_sai_trcs   Switch on idealized stratospheric aerosol injection tracers. Default: off
+     -cldera_clock_trcs Switch on CLDERA clock tracers. Default: off
 EOF
 }
 
@@ -323,6 +324,7 @@ my %opts = (
 GetOptions(
     "age_of_air_trcs!"          => \$opts{'age_of_air_trcs'},
     "cldera_sai_trcs!"          => \$opts{'cldera_sai_trcs'},
+    "cldera_clock_trcs!"        => \$opts{'cldera_clock_trcs'},
     "aquaplanet"                => \$opts{'aquaplanet'},
     "cache=s"                   => \$opts{'cache'},
     "cachedir=s"                => \$opts{'cachedir'},
@@ -878,6 +880,13 @@ if (defined $opts{'cldera_sai_trcs'}) {
 }
 my $cldera_sai_trcs = $cfg_ref->get('cldera_sai_trcs') ? "ON" : "OFF";
 if ($print>=2) { print "CLDERA SAI tracer package: $cldera_sai_trcs$eol"; }
+
+# Allow user to turn on the cldera clock tracers
+if (defined $opts{'cldera_clock_trcs'}) {
+    $cfg_ref->set('cldera_clock_trcs', $opts{'cldera_clock_trcs'});
+}
+my $cldera_clock_trcs = $cfg_ref->get('cldera_clock_trcs') ? "ON" : "OFF";
+if ($print>=2) { print "CLDERA clock tracer package: $cldera_clock_trcs$eol"; }
 
 # waccmx option
 if (defined $opts{'waccmx'}) {
@@ -1488,6 +1497,11 @@ else {
     if ($cldera_sai_trcs eq "ON") {
 	$nadv += 5;
         if ($print>=2) { print "Advected constituents added by the CLDERA SAI tracer package: 5$eol"; }
+    }
+
+    if ($cldera_clock_trcs eq "ON") {
+	$nadv += 3;
+        if ($print>=2) { print "Advected constituents added by the CLDERA clock tracers package: 4$eol"; }
     }
 
     $cfg_ref->set('nadv', $nadv);

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -4220,6 +4220,23 @@ If this is not specified then they are not read from IC file.
 Default: TRUE
 </entry>
 
+<!-- CLDERA clock tracers -->
+
+<entry id="cldera_clock_tracers_flag" type="logical" category="test_tracers"
+       group="cldera_clock_tracers_nl" valid_values="" >
+If true, CLDERA clock tracers are included.  This variable should not be set
+by the user.  It will be set by build-namelist to be consistent with the
+'-cldera_clock_trcs' argument specified to configure.
+Default: set by configure
+</entry>
+
+<entry id="cldera_clock_read_from_ic_file" type="logical" category="test_tracers"
+       group="cldera_clock_tracers_nl" valid_values="" >
+If true, CLDERA clock tracers are read from the initial conditions file.
+If this is not specified then they are not read from IC file.
+Default: TRUE
+</entry>
+
 <!-- CLDERA SAI tracers -->
 
 <entry id="cldera_sai_tracers_flag" type="logical" category="test_tracers"

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -4220,19 +4220,19 @@ If this is not specified then they are not read from IC file.
 Default: TRUE
 </entry>
 
-<!-- CLDERA clock tracers -->
+<!-- CLDERA passive tracers -->
 
-<entry id="cldera_clock_tracers_flag" type="logical" category="test_tracers"
-       group="cldera_clock_tracers_nl" valid_values="" >
-If true, CLDERA clock tracers are included.  This variable should not be set
+<entry id="cldera_passive_tracers_flag" type="logical" category="test_tracers"
+       group="cldera_passive_tracers_nl" valid_values="" >
+If true, CLDERA passive tracers are included.  This variable should not be set
 by the user.  It will be set by build-namelist to be consistent with the
-'-cldera_clock_trcs' argument specified to configure.
+'-cldera_passive_trcs' argument specified to configure.
 Default: set by configure
 </entry>
 
-<entry id="cldera_clock_read_from_ic_file" type="logical" category="test_tracers"
-       group="cldera_clock_tracers_nl" valid_values="" >
-If true, CLDERA clock tracers are read from the initial conditions file.
+<entry id="cldera_passive_read_from_ic_file" type="logical" category="test_tracers"
+       group="cldera_passive_tracers_nl" valid_values="" >
+If true, CLDERA passive tracers are read from the initial conditions file.
 If this is not specified then they are not read from IC file.
 Default: TRUE
 </entry>

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -28,6 +28,10 @@ module mo_gas_phase_chemdr
   integer :: ndx_h2so4
   integer :: inv_ndx_cnst_o3, inv_ndx_m
 
+  !AH
+  integer :: st80_25_ndx
+  integer :: st80_25_tau_ndx
+
   character(len=fieldname_len),dimension(rxntot-phtcnt) :: rxn_names
   character(len=fieldname_len),dimension(phtcnt)        :: pht_names
   character(len=fieldname_len),dimension(rxt_tag_cnt)   :: tag_names
@@ -63,6 +67,10 @@ contains
          convproc_do_aer_out = convproc_do_aer ) 
    
     ndx_h2so4 = get_spc_ndx('H2SO4')
+
+    !AH
+    st80_25_ndx     = get_spc_ndx   ('ST80_25')
+    st80_25_tau_ndx = get_rxt_ndx   ('ST80_25_tau')
 
     het1_ndx= get_rxt_ndx('het1')
     o3_ndx  = get_spc_ndx('O3')
@@ -449,7 +457,15 @@ contains
     !-----------------------------------------------------------------------      
     !        ... Xform from mmr to vmr
     !-----------------------------------------------------------------------      
-    call mmr2vmr( mmr, vmr, mbar, ncol )
+
+    !    call mmr2vmr( mmr, vmr, mbar, ncol )
+    !AH -- added ST80
+    call mmr2vmr( mmr(:ncol,:,:), vmr(:ncol,:,:), mbar(:ncol,:), ncol )
+    if ( st80_25_ndx > 0 ) then
+       where ( pmid(:ncol,:) < 80.e+2_r8 )
+          vmr(:ncol,:,st80_25_ndx) = 200.e-9_r8
+       end where
+    end if
 
     if (h2o_ndx>0) then
        !-----------------------------------------------------------------------      

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -450,7 +450,7 @@ contains
     !        ... Xform from mmr to vmr
     !-----------------------------------------------------------------------      
     call mmr2vmr( mmr, vmr, mbar, ncol )
-    
+ 
     if (h2o_ndx>0) then
        !-----------------------------------------------------------------------      
        !        ... store water vapor in wrk variable

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -450,7 +450,7 @@ contains
     !        ... Xform from mmr to vmr
     !-----------------------------------------------------------------------      
     call mmr2vmr( mmr, vmr, mbar, ncol )
- 
+
     if (h2o_ndx>0) then
        !-----------------------------------------------------------------------      
        !        ... store water vapor in wrk variable

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -28,10 +28,6 @@ module mo_gas_phase_chemdr
   integer :: ndx_h2so4
   integer :: inv_ndx_cnst_o3, inv_ndx_m
 
-  !AH
-  integer :: st80_25_ndx
-  integer :: st80_25_tau_ndx
-
   character(len=fieldname_len),dimension(rxntot-phtcnt) :: rxn_names
   character(len=fieldname_len),dimension(phtcnt)        :: pht_names
   character(len=fieldname_len),dimension(rxt_tag_cnt)   :: tag_names
@@ -67,10 +63,6 @@ contains
          convproc_do_aer_out = convproc_do_aer ) 
    
     ndx_h2so4 = get_spc_ndx('H2SO4')
-
-    !AH
-    st80_25_ndx     = get_spc_ndx   ('ST80_25')
-    st80_25_tau_ndx = get_rxt_ndx   ('ST80_25_tau')
 
     het1_ndx= get_rxt_ndx('het1')
     o3_ndx  = get_spc_ndx('O3')
@@ -457,16 +449,8 @@ contains
     !-----------------------------------------------------------------------      
     !        ... Xform from mmr to vmr
     !-----------------------------------------------------------------------      
-
-    !    call mmr2vmr( mmr, vmr, mbar, ncol )
-    !AH -- added ST80
-    call mmr2vmr( mmr(:ncol,:,:), vmr(:ncol,:,:), mbar(:ncol,:), ncol )
-    if ( st80_25_ndx > 0 ) then
-       where ( pmid(:ncol,:) < 80.e+2_r8 )
-          vmr(:ncol,:,st80_25_ndx) = 200.e-9_r8
-       end where
-    end if
-
+    call mmr2vmr( mmr, vmr, mbar, ncol )
+    
     if (h2o_ndx>0) then
        !-----------------------------------------------------------------------      
        !        ... store water vapor in wrk variable

--- a/components/eam/src/control/runtime_opts.F90
+++ b/components/eam/src/control/runtime_opts.F90
@@ -253,6 +253,7 @@ contains
    use tropopause,          only: tropopause_readnl
    use aoa_tracers,         only: aoa_tracers_readnl
    use cldera_sai_tracers,  only: cldera_sai_tracers_readnl
+   use cldera_clock_tracers,only: cldera_clock_tracers_readnl
    use prescribed_ozone,    only: prescribed_ozone_readnl
    use prescribed_aero,     only: prescribed_aero_readnl
    use prescribed_ghg,      only: prescribed_ghg_readnl
@@ -497,6 +498,7 @@ contains
    call tropopause_readnl(nlfilename)
    call aoa_tracers_readnl(nlfilename)
    call cldera_sai_tracers_readnl(nlfilename)
+   call cldera_clock_tracers_readnl(nlfilename)
    call aerodep_flx_readnl(nlfilename)
    call prescribed_ozone_readnl(nlfilename)
    call prescribed_aero_readnl(nlfilename)

--- a/components/eam/src/control/runtime_opts.F90
+++ b/components/eam/src/control/runtime_opts.F90
@@ -253,7 +253,7 @@ contains
    use tropopause,          only: tropopause_readnl
    use aoa_tracers,         only: aoa_tracers_readnl
    use cldera_sai_tracers,  only: cldera_sai_tracers_readnl
-   use cldera_clock_tracers,only: cldera_clock_tracers_readnl
+   use cldera_passive_tracers,only: cldera_passive_tracers_readnl
    use prescribed_ozone,    only: prescribed_ozone_readnl
    use prescribed_aero,     only: prescribed_aero_readnl
    use prescribed_ghg,      only: prescribed_ghg_readnl
@@ -498,7 +498,7 @@ contains
    call tropopause_readnl(nlfilename)
    call aoa_tracers_readnl(nlfilename)
    call cldera_sai_tracers_readnl(nlfilename)
-   call cldera_clock_tracers_readnl(nlfilename)
+   call cldera_passive_tracers_readnl(nlfilename)
    call aerodep_flx_readnl(nlfilename)
    call prescribed_ozone_readnl(nlfilename)
    call prescribed_aero_readnl(nlfilename)

--- a/components/eam/src/dynamics/se/inidat.F90
+++ b/components/eam/src/dynamics/se/inidat.F90
@@ -47,7 +47,10 @@ contains
     use chemistry,               only: chem_implements_cnst, chem_init_cnst
     use tracers,                 only: tracers_implements_cnst, tracers_init_cnst
     use aoa_tracers,             only: aoa_tracers_implements_cnst, aoa_tracers_init_cnst
-    use cldera_sai_tracers,      only: cldera_sai_tracers_implements_cnst, cldera_sai_tracers_init_cnst
+    use cldera_sai_tracers,      only: cldera_sai_tracers_implements_cnst, &
+                                       cldera_sai_tracers_init_cnst
+    use cldera_clock_tracers,    only: cldera_clock_tracers_implements_cnst, &
+                                       cldera_clock_tracers_init_cnst
     use clubb_intr,              only: clubb_implements_cnst, clubb_init_cnst
     use stratiform,              only: stratiform_implements_cnst, stratiform_init_cnst
     use microp_driver,           only: microp_driver_implements_cnst, microp_driver_init_cnst
@@ -368,6 +371,10 @@ contains
              call aoa_tracers_init_cnst(cnst_name(m_cnst), qtmp, gcid)
               if(par%masterproc) write(iulog,*) '          ', cnst_name(m_cnst), &
                    ' initialized by "aoa_tracers_init_cnst"'
+          else if (cldera_clock_tracers_implements_cnst(cnst_name(m_cnst))) then
+             call cldera_clock_tracers_init_cnst(cnst_name(m_cnst), qtmp, gcid)
+              if(par%masterproc) write(iulog,*) '          ', cnst_name(m_cnst), &
+                   ' initialized by "cldera_clock_tracers_init_cnst"'
           else if (cldera_sai_tracers_implements_cnst(cnst_name(m_cnst))) then
              call cldera_sai_tracers_init_cnst(cnst_name(m_cnst), qtmp, gcid)
               if(par%masterproc) write(iulog,*) '          ', cnst_name(m_cnst), &

--- a/components/eam/src/dynamics/se/inidat.F90
+++ b/components/eam/src/dynamics/se/inidat.F90
@@ -49,7 +49,7 @@ contains
     use aoa_tracers,             only: aoa_tracers_implements_cnst, aoa_tracers_init_cnst
     use cldera_sai_tracers,      only: cldera_sai_tracers_implements_cnst, &
                                        cldera_sai_tracers_init_cnst
-    use cldera_passive_tracers,    only: cldera_passive_tracers_implements_cnst, &
+    use cldera_passive_tracers,  only: cldera_passive_tracers_implements_cnst, &
                                        cldera_passive_tracers_init_cnst
     use clubb_intr,              only: clubb_implements_cnst, clubb_init_cnst
     use stratiform,              only: stratiform_implements_cnst, stratiform_init_cnst

--- a/components/eam/src/dynamics/se/inidat.F90
+++ b/components/eam/src/dynamics/se/inidat.F90
@@ -49,8 +49,8 @@ contains
     use aoa_tracers,             only: aoa_tracers_implements_cnst, aoa_tracers_init_cnst
     use cldera_sai_tracers,      only: cldera_sai_tracers_implements_cnst, &
                                        cldera_sai_tracers_init_cnst
-    use cldera_clock_tracers,    only: cldera_clock_tracers_implements_cnst, &
-                                       cldera_clock_tracers_init_cnst
+    use cldera_passive_tracers,    only: cldera_passive_tracers_implements_cnst, &
+                                       cldera_passive_tracers_init_cnst
     use clubb_intr,              only: clubb_implements_cnst, clubb_init_cnst
     use stratiform,              only: stratiform_implements_cnst, stratiform_init_cnst
     use microp_driver,           only: microp_driver_implements_cnst, microp_driver_init_cnst
@@ -371,10 +371,10 @@ contains
              call aoa_tracers_init_cnst(cnst_name(m_cnst), qtmp, gcid)
               if(par%masterproc) write(iulog,*) '          ', cnst_name(m_cnst), &
                    ' initialized by "aoa_tracers_init_cnst"'
-          else if (cldera_clock_tracers_implements_cnst(cnst_name(m_cnst))) then
-             call cldera_clock_tracers_init_cnst(cnst_name(m_cnst), qtmp, gcid)
+          else if (cldera_passive_tracers_implements_cnst(cnst_name(m_cnst))) then
+             call cldera_passive_tracers_init_cnst(cnst_name(m_cnst), qtmp, gcid)
               if(par%masterproc) write(iulog,*) '          ', cnst_name(m_cnst), &
-                   ' initialized by "cldera_clock_tracers_init_cnst"'
+                   ' initialized by "cldera_passive_tracers_init_cnst"'
           else if (cldera_sai_tracers_implements_cnst(cnst_name(m_cnst))) then
              call cldera_sai_tracers_init_cnst(cnst_name(m_cnst), qtmp, gcid)
               if(par%masterproc) write(iulog,*) '          ', cnst_name(m_cnst), &

--- a/components/eam/src/physics/cam/cldera_clock_tracers.F90
+++ b/components/eam/src/physics/cam/cldera_clock_tracers.F90
@@ -1,0 +1,427 @@
+!===============================================================================
+! CLDERA clock tracers
+! provides dissipation rates and sources for diagnostic constituents
+!
+! AOA tracer implemented as defined in:
+! Gupta, A., Gerber, E.P. and Lauritzen, P.H. (2020) 
+! Numerical impacts on tracer transport: A proposed intercomparison test of Atmospheric 
+! General Circulation Models, Quarterly Journal of the Royal Meteorological Society,
+! doi:10.1002/qj.3881.
+!
+! E90 tracer implemented as defined in:
+! Abalos, M. et al. (2017)
+! Using the Artificial Tracer e90 to Examine Present and Future UTLS Tracer Transport in WACCM, 
+! Journal of the Atmospheric Sciences,
+! doi:10.1175/JAS-D-17-0135.1.
+! 
+! ST80 tracer implemented as defined in
+! Eyring, V. et al. (2013)
+! Overview of IGAC/SPARC Chemistry-Climate Model Initiative (CCMI) Community Simulations in 
+! Support of Upcoming Ozone and Climate Assessments
+!
+!===============================================================================
+
+module cldera_clock_tracers
+
+  use shr_kind_mod, only: r8 => shr_kind_r8
+  use spmd_utils,   only: masterproc
+  use ppgrid,       only: pcols, pver
+  use constituents, only: pcnst, cnst_add, cnst_name, cnst_longname
+  use cam_logfile,  only: iulog
+  use ref_pres,     only: pref_mid_norm
+
+  implicit none
+  private
+  save
+
+  ! Public interfaces
+  public :: cldera_clock_tracers_register         ! register constituents
+  public :: cldera_clock_tracers_implements_cnst  ! true if constituent is implemented by this package
+  public :: cldera_clock_tracers_init_cnst        ! initialize constituent field
+  public :: cldera_clock_tracers_init             ! initialize history fields, datasets
+  public :: cldera_clock_tracers_timestep_init    ! place to perform per timestep initialization
+  public :: cldera_clock_tracers_timestep_tend    ! calculate tendencies
+  public :: cldera_clock_tracers_readnl           ! read namelist options
+
+  ! Private module data
+
+  integer, parameter :: ncnst=3  ! number of constituents implemented by this module
+
+  ! constituent names
+  character(len=8), parameter :: c_names(ncnst) = (/'AOA', 'E90', 'ST80'/)
+
+  integer :: ifirst ! global index of first constituent
+  integer :: ixaoa  ! global index for AOA tracer
+  integer :: ixe90  ! global index for E90 tracer
+  integer :: ixst80 ! global index for ST80 tracer
+
+  ! Data from namelist variables
+  logical :: cldera_clock_tracers_flag  = .false.    ! true => turn on test tracer code, namelist variable
+  logical :: cldera_clock_read_from_ic_file = .true. ! true => tracers initialized from IC file
+
+!===============================================================================
+contains
+!===============================================================================
+
+!================================================================================
+  subroutine cldera_clock_tracers_readnl(nlfile)
+
+    use namelist_utils, only: find_group_name
+    use units,          only: getunit, freeunit
+    use mpishorthand
+    use cam_abortutils,     only: endrun
+
+    implicit none
+
+    character(len=*), intent(in) :: nlfile  ! filepath for file containing namelist input
+
+    ! Local variables
+    integer :: unitn, ierr
+    character(len=*), parameter :: subname = 'cldera_clock_tracers_readnl'
+
+
+    namelist /cldera_clock_tracers_nl/ cldera_clock_tracers_flag, cldera_clock_read_from_ic_file
+
+    !-----------------------------------------------------------------------------
+
+    if (masterproc) then
+       unitn = getunit()
+       open( unitn, file=trim(nlfile), status='old' )
+       call find_group_name(unitn, 'cldera_clock_tracers_nl', status=ierr)
+       if (ierr == 0) then
+          read(unitn, cldera_clock_tracers_nl, iostat=ierr)
+          if (ierr /= 0) then
+             call endrun(subname // ':: ERROR reading namelist')
+          end if
+       end if
+       close(unitn)
+       call freeunit(unitn)
+    end if
+
+#ifdef SPMD
+    call mpibcast(cldera_clock_tracers_flag, 1, mpilog,  0, mpicom)
+    call mpibcast(cldera_clock_read_from_ic_file, 1, mpilog,  0, mpicom)
+#endif
+
+  endsubroutine cldera_clock_tracers_readnl
+
+!================================================================================
+
+  subroutine cldera_clock_tracers_register
+    !----------------------------------------------------------------------- 
+    ! 
+    ! Purpose: register advected constituents
+    ! 
+    !-----------------------------------------------------------------------
+    use physconst,  only: cpair, mwdry
+    !-----------------------------------------------------------------------
+
+    if (.not. cldera_clock_tracers_flag) return
+
+    call cnst_add(c_names(1), mwdry, cpair, 0._r8, ixaoa,  readiv=cldera_clock_read_from_ic_file, &
+                  longname='Age-of-air tracer')
+    ifirst = ixaoa
+    call cnst_add(c_names(2), mwdry, cpair, 0._r8, ixe90,  readiv=cldera_clock_read_from_ic_file, &
+                  longname='E90 tracer')
+    call cnst_add(c_names(3), mwdry, cpair, 0._r8, ixst80, readiv=cldera_clock_read_from_ic_file, &
+                  longname='ST80 tracer')
+
+  end subroutine cldera_clock_tracers_register
+
+!===============================================================================
+
+  function cldera_clock_tracers_implements_cnst(name)
+    !----------------------------------------------------------------------- 
+    ! 
+    ! Purpose: return true if specified constituent is implemented by this package
+    ! 
+    !-----------------------------------------------------------------------
+
+    character(len=*), intent(in) :: name   ! constituent name
+    logical :: cldera_clock_tracers_implements_cnst        ! return value
+
+    !---------------------------Local workspace-----------------------------
+    integer :: m
+    !-----------------------------------------------------------------------
+
+    cldera_clock_tracers_implements_cnst = .false.
+
+    if (.not. cldera_clock_tracers_flag) return
+
+    do m = 1, ncnst
+       if (name == c_names(m)) then
+          cldera_clock_tracers_implements_cnst = .true.
+          return
+       end if
+    end do
+
+  end function cldera_clock_tracers_implements_cnst
+
+!===============================================================================
+
+  subroutine cldera_clock_tracers_init_cnst(name, q, gcid)
+
+    !----------------------------------------------------------------------- 
+    !
+    ! Purpose: initialize test tracers mixing ratio fields 
+    !  This subroutine is called at the beginning of an initial run ONLY
+    !
+    !-----------------------------------------------------------------------
+
+    character(len=*), intent(in)  :: name
+    real(r8),         intent(out) :: q(:,:)   ! kg tracer/kg dry air (gcol, plev)
+    integer,          intent(in)  :: gcid(:)  ! global column id
+
+    integer :: m
+    !-----------------------------------------------------------------------
+
+    if (.not. cldera_clock_tracers_flag) return
+
+    do m = 1, ncnst
+       if (name ==  c_names(m))  then
+          ! pass global constituent index
+          call init_cnst_3d(ifirst+m-1, q, gcid)
+       endif
+    end do
+
+  end subroutine cldera_clock_tracers_init_cnst
+
+!===============================================================================
+
+  subroutine cldera_clock_tracers_init
+
+    !----------------------------------------------------------------------- 
+    ! 
+    ! Purpose: initialize age of air constituents
+    !          (declare history variables)
+    !-----------------------------------------------------------------------
+
+    use cam_history,    only: addfld, add_default
+
+    integer :: m, mm
+    !-----------------------------------------------------------------------
+
+    if (.not. cldera_clock_tracers_flag) return
+
+    ! Set names of tendencies and declare them as history variables
+
+    do m = 1, ncnst
+       mm = ifirst+m-1
+       call addfld (cnst_name(mm), (/ 'lev' /), 'A', 'kg/kg', cnst_longname(mm))
+       call add_default (cnst_name(mm), 1, ' ')
+    end do
+
+  end subroutine cldera_clock_tracers_init
+
+!===============================================================================
+
+  subroutine cldera_clock_tracers_timestep_init( phys_state )
+    !-----------------------------------------------------------------------
+    ! Provides a place to reinitialize diagnostic constituents
+    ! Currently does nothing
+    !-----------------------------------------------------------------------
+
+    use time_manager,   only: get_curr_date
+    use ppgrid,         only: begchunk, endchunk
+    use physics_types,  only: physics_state
+
+    type(physics_state), intent(inout), dimension(begchunk:endchunk), optional :: phys_state    
+
+
+    integer c, i, k, ncol
+    integer yr, mon, day, tod
+    !--------------------------------------------------------------------------
+
+    if (.not. cldera_clock_tracers_flag) return
+
+    call get_curr_date (yr,mon,day,tod)
+
+    if ( day == 1 .and. tod == 0) then
+       if (masterproc) then
+         write(iulog,*) 'CLDERA_CLOCK_CONSTITUENTS: RE-INITIALIZING CONSTITUENTS'
+       endif
+
+       do c = begchunk, endchunk
+          ncol = phys_state(c)%ncol
+          do k = 1, pver
+             do i = 1, ncol
+                ! does nothing currently
+                continue
+             end do
+          end do
+       end do
+
+    end if
+
+  end subroutine cldera_clock_tracers_timestep_init
+
+!===============================================================================
+
+  subroutine cldera_clock_tracers_timestep_tend(state, ptend, dt)
+
+    use physics_types, only: physics_state, physics_ptend, physics_ptend_init
+    use phys_grid,     only: get_rlat_all_p , get_lat_all_p
+    use physconst,     only: gravit
+    use cam_history,   only: outfld
+    use time_manager,  only: get_nstep
+    use ref_pres,      only: pref_mid_norm
+    use time_manager,  only: get_curr_time
+
+    ! Arguments
+    type(physics_state), intent(inout)    :: state           ! state variables
+    type(physics_ptend), intent(out)   :: ptend              ! package tendencies
+    real(r8),            intent(in)    :: dt                 ! timestep
+    !real(r8),           intent(inout) :: cflx(pcols,pcnst)  ! Surface constituent flux (kg/m^2/s)
+
+    !----------------- Local workspace-------------------------------
+
+    integer :: i, k
+    integer :: lchnk             ! chunk identifier
+    integer :: ncol              ! no. of column in chunk
+    integer :: nstep             ! current timestep number
+
+    logical  :: lq(pcnst)
+
+    integer  :: day,sec          ! date variables
+    real(r8) :: t                ! tracer boundary condition
+    real(r8) :: aoa_scaling      ! scale AOA1 from nstep to time
+
+    real(r8) :: efold_st80       ! e-folding timescale for e90 in s
+    real(r8) :: efold_e90        ! e-folding timescale for e90 in s
+    real(r8) :: mweight_e90      ! molecular weight of E90 in g/mol
+    real(r8) :: sflx_e90         ! surface flux of E90 in mol cm^-2 s^-1
+
+    !------------------------------------------------------------------
+
+    if (.not. cldera_clock_tracers_flag) then
+       !Initialize an empty ptend for use with physics_update
+       call physics_ptend_init(ptend,state%psetcols,'cldera_clock_trc_ts')
+       return
+    end if
+
+    lq(:)      = .FALSE.
+    lq(ixaoa)  = .TRUE.
+    lq(ixe90)  = .TRUE.
+    lq(ixst80) = .TRUE.
+    call physics_ptend_init(ptend,state%psetcols, 'cldera_clock_tracers', lq=lq)
+
+    nstep = get_nstep()
+    lchnk = state%lchnk
+    ncol  = state%ncol
+
+    ! ---- compute AOA time scaling (1 s in days)
+    aoa_scaling = 1._r8/86400._r8
+
+    ! ---- e-folding times for e90 (90 days in s), st80 (25 days in s)
+    ! (reciprocals match WACCM 'E90_tau' and 'ST80_tau', and table A2 in 
+    ! Tilmes+ (2016) Representation of CESM1 CAM4-chem within CCMI)
+    efold_e90  = 90._r8 * 86400._r8
+    efold_st80 = 25._r8 * 86400._r8
+
+    ! ---- molecular weight and surface flux for e90
+    ! (surface flux matches Abalos+ (2017), molecular weight is for CO, matches
+    !  WACCM surface emissions specification in 
+    !  emissions_E90global_surface_1750-2100_0.9x1.25_c20170322.nc)
+    mweight_e90 = 28._r8                                   ! molecular weight of CO [g/mole]
+    sflx_e90    = 2.7736e11_r8                             ! [molecules cm^-2 s^-1]
+    sflx_e90    = sflx_e90 / 6.022141e23_r8                ! [moles cm^-2 s^-1]
+    ! convert mol to g, g to kg, cm^-2 to m^-2, ==>  flux in [kg m^-2 s^-1]
+    sflx_e90    = sflx_e90 * mweight_e90 * (1._r8/1000._r8) * 10000._r8
+
+
+    ! -------------------- TRACER TENDENCIES --------------------
+    do k = 1, pver
+       do i = 1, ncol
+       ! the explicit horizontal looping is not currently needed; maintained 
+       ! in case spatial dependence in e.g. AOA is ever desired 
+
+          ! ============ AOA ============
+          ! clock tracer with a source of 1 day/day everywhere above ~700hPa
+          if (pref_mid_norm(k) <= 0.7) then
+              ptend%q(i,k,ixaoa) = 1.0_r8 * aoa_scaling
+          else
+              ptend%q(i,k,ixaoa) = 0.0_r8
+              state%q(i,k,ixaoa) = 0.0_r8
+          end if
+
+          ! ============ E90 ============
+          ! dissipates with e-folding time of 90 days
+          ptend%q(i,k,ixe90) = -(1._r8 / efold_e90) * state%q(i, k, ixe90)
+          ! apply surface flux to lowest model level
+          if(k == pver) then
+              state%q(i, k, ixe90) = state%q(i, k, ixe90) + &
+                                     dt * gravit * 1._r8 / state%pdel(i, k) * sflx_e90
+          end if
+
+          ! ============ ST80 ============
+          ! dissipates with e-folding time of 25 days below ~80 hPa, 
+          ! constant concentration of 200 ppbv above
+          if (pref_mid_norm(k) >= 0.08) then
+              ptend%q(i,k,ixst80) = -(1._r8 / efold_st80) * state%q(i, k, ixst80)
+          else
+              ptend%q(i, k,ixst80) = 0._r8
+              state%q(i, k, ixst80) = 200e-9_r8  ! 200 ppbv to vmr
+          end if
+       end do
+    end do
+
+    ! -------------------- TRACER FLUXES --------------------
+    do i = 1, ncol
+
+       ! ====== AOA ======
+       ! no surface flux
+       !cflx(i,ixaoa) = 0._r8
+
+       ! ====== E90 ======
+       !cflx(i,ixe90) = sflx_e90
+
+       ! ====== ST80 ======
+       ! no surface flux
+       !cflx(i,ixst80) = 0._r8
+       continue
+
+    end do
+
+  end subroutine cldera_clock_tracers_timestep_tend
+
+!===========================================================================
+
+  subroutine init_cnst_3d(m, q, gcid)
+
+    use dyn_grid, only : get_horiz_grid_d, get_horiz_grid_dim_d
+    use dycore,   only : dycore_is
+
+    integer,  intent(in)  :: m       ! global constituent index
+    real(r8), intent(out) :: q(:,:)  ! kg tracer/kg dry air (gcol,plev)
+    integer,  intent(in)  :: gcid(:) ! global column id
+
+    real(r8), allocatable :: lat(:)
+    integer :: plon, plat, ngcols
+    integer :: j, k, gsize
+    !-----------------------------------------------------------------------
+
+    if (masterproc) write(iulog,*) 'CLDERA_CLOCK CONSTITUENTS: INITIALIZING ',cnst_name(m),m
+
+    ! ====== AOA ======
+    if (m == ixaoa) then
+
+       q(:,:) = 0.0_r8
+
+    ! ====== E90 ======
+    else if (m == ixe90) then
+
+       q(:,:) = 0.0_r8
+
+    ! ====== ST80 ======
+    else if (m == ixst80) then
+
+       q(:,:) = 0.0_r8
+
+    end if
+
+  end subroutine init_cnst_3d
+
+!=====================================================================
+
+
+end module cldera_clock_tracers

--- a/components/eam/src/physics/cam/cldera_passive_tracers.F90
+++ b/components/eam/src/physics/cam/cldera_passive_tracers.F90
@@ -39,7 +39,6 @@ module cldera_passive_tracers
   public :: cldera_passive_tracers_implements_cnst  ! true if constituent is implemented by this package
   public :: cldera_passive_tracers_init_cnst        ! initialize constituent field
   public :: cldera_passive_tracers_init             ! initialize history fields, datasets
-  public :: cldera_passive_tracers_timestep_init    ! place to perform per timestep initialization
   public :: cldera_passive_tracers_timestep_tend    ! calculate tendencies
   public :: cldera_passive_tracers_readnl           ! read namelist options
 
@@ -214,48 +213,6 @@ contains
 
 !===============================================================================
 
-  subroutine cldera_passive_tracers_timestep_init( phys_state )
-    !-----------------------------------------------------------------------
-    ! Provides a place to reinitialize diagnostic constituents
-    ! Currently does nothing
-    !-----------------------------------------------------------------------
-
-    use time_manager,   only: get_curr_date
-    use ppgrid,         only: begchunk, endchunk
-    use physics_types,  only: physics_state
-
-    type(physics_state), intent(inout), dimension(begchunk:endchunk), optional :: phys_state    
-
-
-    integer c, i, k, ncol
-    integer yr, mon, day, tod
-    !--------------------------------------------------------------------------
-
-    if (.not. cldera_passive_tracers_flag) return
-
-    call get_curr_date (yr,mon,day,tod)
-
-    if ( day == 1 .and. tod == 0) then
-       if (masterproc) then
-         write(iulog,*) 'CLDERA_CLOCK_CONSTITUENTS: RE-INITIALIZING CONSTITUENTS'
-       endif
-
-       do c = begchunk, endchunk
-          ncol = phys_state(c)%ncol
-          do k = 1, pver
-             do i = 1, ncol
-                ! does nothing currently
-                continue
-             end do
-          end do
-       end do
-
-    end if
-
-  end subroutine cldera_passive_tracers_timestep_init
-
-!===============================================================================
-
   subroutine cldera_passive_tracers_timestep_tend(state, ptend, dt, cflx)
 
     use physics_types, only: physics_state, physics_ptend, physics_ptend_init
@@ -329,8 +286,6 @@ contains
     ! -------------------- TRACER TENDENCIES --------------------
     do k = 1, pver
        do i = 1, ncol
-       ! the explicit horizontal looping is not currently needed; maintained 
-       ! in case spatial dependence in e.g. AOA is ever desired 
 
           ! ============ AOA ============
           ! clock tracer with a source of 1 day/day everywhere above ~700hPa
@@ -402,7 +357,7 @@ contains
     ! initialization below is on the DYNAMICS grid; length of gcol will 
     ! be number of GLL points, not number of physics columns
 
-    if (masterproc) write(iulog,*) 'CLDERA_CLOCK CONSTITUENTS: INITIALIZING ',cnst_name(m),m
+    if (masterproc) write(iulog,*) 'CLDERA PASSIVE CONSTITUENTS: INITIALIZING ',cnst_name(m),m
 
     ! ====== AOA ======
     if (m == ixaoa) then

--- a/components/eam/src/physics/cam/cldera_passive_tracers.F90
+++ b/components/eam/src/physics/cam/cldera_passive_tracers.F90
@@ -14,7 +14,7 @@
 ! Journal of the Atmospheric Sciences,
 ! doi:10.1175/JAS-D-17-0135.1.
 ! 
-! ST80 tracer implemented as defined in
+! ST80_25 tracer implemented as defined in
 ! Eyring, V. et al. (2013)
 ! Overview of IGAC/SPARC Chemistry-Climate Model Initiative (CCMI) Community Simulations in 
 ! Support of Upcoming Ozone and Climate Assessments
@@ -48,12 +48,12 @@ module cldera_passive_tracers
   integer, parameter :: ncnst=3  ! number of constituents implemented by this module
 
   ! constituent names
-  character(len=8), parameter :: c_names(ncnst) = (/'AOA', 'E90', 'ST80'/)
+  character(len=8), parameter :: c_names(ncnst) = (/'AOA', 'E90', 'ST80_25'/)
 
   integer :: ifirst ! global index of first constituent
   integer :: ixaoa  ! global index for AOA tracer
   integer :: ixe90  ! global index for E90 tracer
-  integer :: ixst80 ! global index for ST80 tracer
+  integer :: ixst80 ! global index for ST80_25 tracer
 
   ! Data from namelist variables
   logical :: cldera_passive_tracers_flag  = .false.    ! true => turn on test tracer code, namelist variable
@@ -124,7 +124,7 @@ contains
     call cnst_add(c_names(2), mwdry, cpair, 0._r8, ixe90,  readiv=cldera_passive_read_from_ic_file, &
                   longname='E90 tracer')
     call cnst_add(c_names(3), mwdry, cpair, 0._r8, ixst80, readiv=cldera_passive_read_from_ic_file, &
-                  longname='ST80 tracer')
+                  longname='ST80_25 tracer')
 
   end subroutine cldera_passive_tracers_register
 
@@ -313,7 +313,7 @@ contains
     aoa_scaling = 1._r8/86400._r8
 
     ! ---- e-folding times for e90 (90 days in s), st80 (25 days in s)
-    ! (reciprocals match WACCM 'E90_tau' and 'ST80_tau', and table A2 in 
+    ! (reciprocals match WACCM 'E90_tau' and 'ST80_25_tau', and table A2 in 
     ! Tilmes+ (2016) Representation of CESM1 CAM4-chem within CCMI)
     efold_e90  = 90._r8 * 86400._r8
     efold_st80 = 25._r8 * 86400._r8
@@ -353,7 +353,7 @@ contains
                                      dt * gravit * 1._r8 / state%pdel(i, k) * sflx_e90
           end if
 
-          ! ============ ST80 ============
+          ! ============ ST80_25 ============
           ! dissipates with e-folding time of 25 days below ~80 hPa, 
           ! constant concentration of 200 ppbv above
           if (pref_mid_norm(k) >= 0.08) then
@@ -375,7 +375,7 @@ contains
        ! ====== E90 ======
        !cflx(i,ixe90) = sflx_e90
 
-       ! ====== ST80 ======
+       ! ====== ST80_25 ======
        ! no surface flux
        !cflx(i,ixst80) = 0._r8
        continue
@@ -412,7 +412,7 @@ contains
 
        q(:,:) = 0.0_r8
 
-    ! ====== ST80 ======
+    ! ====== ST80_25 ======
     else if (m == ixst80) then
 
        q(:,:) = 0.0_r8

--- a/components/eam/src/physics/cam/cldera_passive_tracers.F90
+++ b/components/eam/src/physics/cam/cldera_passive_tracers.F90
@@ -210,12 +210,6 @@ contains
        call add_default (cnst_name(mm), 1, ' ')
     end do
     
-    ! add other output fields 
-    call addfld('SFE90j',  horiz_only, 'A', 'kg/m2/s', 'E90j surface flux' )
-    call add_default('SFE90j', 1, ' ')
-    call addfld('SFE90j2',  horiz_only, 'A', 'kg/m2/s', 'E90j surface flux' )
-    call add_default('SFE90j2', 1, ' ')
-
   end subroutine cldera_passive_tracers_init
 
 !===============================================================================
@@ -262,7 +256,7 @@ contains
 
 !===============================================================================
 
-  subroutine cldera_passive_tracers_timestep_tend(state, ptend, dt, cflx, use_cflx)
+  subroutine cldera_passive_tracers_timestep_tend(state, ptend, dt, cflx)
 
     use physics_types, only: physics_state, physics_ptend, physics_ptend_init
     use phys_grid,     only: get_rlat_all_p , get_lat_all_p
@@ -277,12 +271,6 @@ contains
     type(physics_ptend), intent(out)   :: ptend              ! package tendencies
     real(r8),            intent(in)    :: dt                 ! timestep
     real(r8),            intent(inout) :: cflx(pcols,pcnst)  ! Surface constituent flux (kg/m^2/s)
-    logical,             intent(in)    :: use_cflx           ! If True, update surface flux through 
-                                                             ! input cflx structure. If False, assume
-                                                             ! input cflx was a dummy, and instead
-                                                             ! compute lowest-level tendency directly
-                                                             ! (needed for FIDEAL where cam_in has no
-                                                             ! cflx)
 
     !----------------- Local workspace-------------------------------
 
@@ -299,13 +287,8 @@ contains
 
     real(r8) :: efold_st80       ! e-folding timescale for e90 in s
     real(r8) :: efold_e90        ! e-folding timescale for e90 in s
-    real(r8) :: st80_tau         ! reciprocal e-folding timescale for e90 in s
-    real(r8) :: e90_tau          ! reciprocal e-folding timescale for e90 in s
     real(r8) :: mweight_e90      ! molecular weight of E90 in g/mol
     real(r8) :: sflx_e90         ! surface flux of E90 in mol cm^-2 s^-1
-    real(r8) :: amufac           ! 1.e4* kg / amu, constant taken 
-                                 ! from mo_srf_emissions.F90 
-    real(r8) :: sflx_e90_out(pcols,pcnst)
 
     !------------------------------------------------------------------
 
@@ -329,12 +312,8 @@ contains
     aoa_scaling = 1._r8/86400._r8
 
     ! ---- e-folding times for e90 (90 days in s), st80 (25 days in s)
-    ! (reciprocals match WACCM 'E90_tau' and 'ST80_25_tau', and table A2 in 
-    ! Tilmes+ (2016) Representation of CESM1 CAM4-chem within CCMI)
     efold_e90  = 90._r8 * 86400._r8
     efold_st80 = 25._r8 * 86400._r8
-    e90_tau    = 1.29e-7  ! approximated reciprocals of the above values to agree exactly
-    st80_tau   = 4.63e-7  ! with values used in WACCM... these used below 
 
     ! ---- molecular weight and surface flux for e90
     ! (surface flux matches Abalos+ (2017), molecular weight is for CO, matches
@@ -342,18 +321,9 @@ contains
     !  emissions_E90global_surface_1750-2100_0.9x1.25_c20170322.nc)
     mweight_e90 = 28._r8                                   ! molecular weight of CO [g/mole]
     sflx_e90    = 2.773063e11_r8                           ! [molecules cm^-2 s^-1]
-    
-    ! manually setting this to consistent with mozart after conversion...
-    sflx_e90 = 1.289235e-10_r8
-
-    !amufac      = 1.65979e-23_r8                           ! 1.e4* kg / amu
-    !sflx_e90    = sflx_e90 * mweight_e90 * amufac
-    
-    ! -- this is more correct on paper... but am going to switch to a scaling consistent
-    ! -- with the that used by mozart for reading in surface emissions
-    !sflx_e90    = sflx_e90 / (avogad / 1000)               ! [moles cm^-2 s^-1] 
+    sflx_e90    = sflx_e90 / (avogad / 1000)               ! [moles cm^-2 s^-1] 
     ! convert mol to g, g to kg, cm^-2 to m^-2, ==>  flux in [kg m^-2 s^-1]
-    !sflx_e90    = sflx_e90 * mweight_e90 * (1._r8/1000._r8) * 10000._r8
+    sflx_e90    = sflx_e90 * mweight_e90 * (1._r8/1000._r8) * 10000._r8
 
 
     ! -------------------- TRACER TENDENCIES --------------------
@@ -373,28 +343,21 @@ contains
 
           ! ============ E90 ============
           ! dissipates with e-folding time of 90 days
-          ptend%q(i,k,ixe90) =  -e90_tau * state%q(i, k, ixe90)
+          ptend%q(i,k,ixe90) =  -(1/efold_e90) * state%q(i, k, ixe90)
           ! apply surface flux to lowest model level
           ! this mimics behavior of vertical_diffusion_tend()
           ! last line adjusts for dry constituent
-          if(k == pver .and. use_cflx == .false. ) then
+          if(k == pver) then
               ptend%q(i, k, ixe90) = ptend%q(i, k, ixe90) + &
                                      gravit * state%rpdel(i, k) * sflx_e90 * & 
                                      state%pdel(i,k) / state%pdeldry(i, k)
-
-              sflx_e90_out(i,ixe90) = sflx_e90
-              !state%q(i, k, ixe90) = state%q(i, k, ixe90) + &
-              !                       dt * gravit * state%rpdel(i, k) * sflx_e90 * & 
-              !                       state%pdel(i,k) / state%pdeldry(i, k)
-              !write(iulog,*) 'E90_jh sflx: ' sflx_e90
-              !write(iulog,*) 'E90_jh surface tend: ' dt * gravit * state%rpdel(i, k) * sflx_e90
           end if
 
           ! ============ ST80_25 ============
           ! dissipates with e-folding time of 25 days below ~80 hPa, 
           ! constant concentration of 200 ppbv above
           if (state%pmid(i, k) >= 8000._r8) then
-              ptend%q(i,k,ixst80) =  -st80_tau * state%q(i, k, ixst80)
+              ptend%q(i,k,ixst80) =  -(1/efold_st80) * state%q(i, k, ixst80)
           else
               ptend%q(i, k,ixst80) = 0._r8
               state%q(i, k, ixst80) = 200e-9_r8  ! 200 ppbv to vmr
@@ -404,26 +367,19 @@ contains
 
     ! -------------------- TRACER FLUXES --------------------
     do i = 1, ncol
-       if (use_cflx == .true.) then
-           ! run only if the caller has provided cam_in%cflx (in which case use_cflx should be true)
+       ! ====== AOA ======
+       ! no surface flux
+       cflx(i,ixaoa) = 0._r8
 
-           ! ====== AOA ======
-           ! no surface flux
-           cflx(i,ixaoa) = 0._r8
+       ! ====== E90 ======
+       ! surface flux handled in tendency computation above
+       cflx(i,ixe90) = 0._r8
 
-           ! ====== E90 ======
-           cflx(i,ixe90) = sflx_e90
-           ! record E90 surface flux to history files
-
-           ! ====== ST80_25 ======
-           ! no surface flux
-           cflx(i,ixst80) = 0._r8
-       end if
+       ! ====== ST80_25 ======
+       ! no surface flux
+       cflx(i,ixst80) = 0._r8
     end do
            
-    call outfld('SFE90j',  cflx(:,ixe90), ncol, lchnk)
-    call outfld('SFE90j2', sflx_e90_out(:,ixe90), ncol, lchnk)
-    
 
   end subroutine cldera_passive_tracers_timestep_tend
 

--- a/components/eam/src/physics/cam/cldera_passive_tracers.F90
+++ b/components/eam/src/physics/cam/cldera_passive_tracers.F90
@@ -46,7 +46,7 @@ module cldera_passive_tracers
   integer, parameter :: ncnst=3  ! number of constituents implemented by this module
 
   ! constituent names
-  character(len=8), parameter :: c_names(ncnst) = (/'AOA', 'E90j', 'ST80_25j'/)
+  character(len=8), parameter :: c_names(ncnst) = (/'AOA     ', 'E90j    ', 'ST80_25j'/)
 
   integer :: ifirst ! global index of first constituent
   integer :: ixaoa  ! global index for AOA tracer

--- a/components/eam/src/physics/cam/cldera_sai_tracers.F90
+++ b/components/eam/src/physics/cam/cldera_sai_tracers.F90
@@ -351,7 +351,7 @@ contains
        call add_default (cnst_name(mm), 1, ' ')
     end do
     
-    ! add other output fields 
+    ! add other output fields  
     call addfld('AREA',  horiz_only, 'A', 'kg', 'area of grid cell' )
     call add_default('AREA', 1, ' ')
     call addfld('AIR_MASS',  (/ 'lev' /), 'A', 'kg', 'mass of grid box' )

--- a/components/eam/src/physics/cam/cldera_sai_tracers.F90
+++ b/components/eam/src/physics/cam/cldera_sai_tracers.F90
@@ -351,8 +351,7 @@ contains
        call add_default (cnst_name(mm), 1, ' ')
     end do
     
-    ! add other output fields
-    
+    ! add other output fields 
     call addfld('AREA',  horiz_only, 'A', 'kg', 'area of grid cell' )
     call add_default('AREA', 1, ' ')
     call addfld('AIR_MASS',  (/ 'lev' /), 'A', 'kg', 'mass of grid box' )

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -1209,7 +1209,7 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
        call diag_phys_writeout(phys_state(c))
 
        ! --JH--: Allow advecting of CLDERA passive tendencies if enabled
-       call cldera_passive_tracers_timestep_tend(phys_state(c), ptend(c), ztodt, dummy_cflx, .false.)
+       call cldera_passive_tracers_timestep_tend(phys_state(c), ptend(c), ztodt, dummy_cflx)
        call physics_update(phys_state(c), ptend(c), ztodt, phys_tend(c))
        call check_tracers_chng(phys_state(c), tracerint, "cldera_passive_tracers_timestep_tend", &
                                nstep, ztodt, dummy_cflx)
@@ -1686,7 +1686,7 @@ if (l_tracer_aero) then
     call check_tracers_chng(state, tracerint, "aoa_tracers_timestep_tend", nstep, ztodt,   &
          cam_in%cflx)
 
-    call cldera_passive_tracers_timestep_tend(state, ptend, ztodt, cam_in%cflx, .true.)
+    call cldera_passive_tracers_timestep_tend(state, ptend, ztodt, cam_in%cflx)
     call physics_update(state, ptend, ztodt, tend)
     call check_tracers_chng(state, tracerint, "cldera_passive_tracers_timestep_tend", nstep, ztodt, &
                             cam_in%cflx)

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -147,7 +147,7 @@ subroutine phys_register
     use sslt_rebin,         only: sslt_rebin_register
     use aoa_tracers,        only: aoa_tracers_register
     use cldera_sai_tracers, only: cldera_sai_tracers_register
-    use cldera_clock_tracers, only: cldera_clock_tracers_register
+    use cldera_passive_tracers, only: cldera_passive_tracers_register
     use aircraft_emit,      only: aircraft_emit_register
     use cam_diagnostics,    only: diag_register
     use cloud_diagnostics,  only: cloud_diagnostics_register
@@ -318,8 +318,8 @@ subroutine phys_register
     ! Register age of air tracers
     call aoa_tracers_register()
 
-    ! Register CLDERA clock tracers
-    call cldera_clock_tracers_register()
+    ! Register CLDERA passive tracers
+    call cldera_passive_tracers_register()
     
     ! Register CLDERA stratospheric aerosol injection tracers
     call cldera_sai_tracers_register()
@@ -717,7 +717,7 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
     use tracers,            only: tracers_init
     use aoa_tracers,        only: aoa_tracers_init
     use cldera_sai_tracers, only: cldera_sai_tracers_init
-    use cldera_clock_tracers, only: cldera_clock_tracers_init
+    use cldera_passive_tracers, only: cldera_passive_tracers_init
     use rayleigh_friction,  only: rayleigh_friction_init
     use pbl_utils,          only: pbl_utils_init
     use vertical_diffusion, only: vertical_diffusion_init
@@ -788,8 +788,8 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
     ! age of air tracers
     call aoa_tracers_init()
 
-    ! CLDERA clock tracers
-    call cldera_clock_tracers_init()
+    ! CLDERA passive tracers
+    call cldera_passive_tracers_init()
     
     ! CLDERA stratospheric aerosol injection tracers
     call cldera_sai_tracers_init()
@@ -1140,7 +1140,7 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
     use ppgrid,          only: pcols
     use constituents,    only: pcnst
     use cldera_sai_tracers,   only: cldera_sai_tracers_timestep_tend
-    use cldera_clock_tracers, only: cldera_clock_tracers_timestep_tend
+    use cldera_passive_tracers, only: cldera_passive_tracers_timestep_tend
 
     !
     ! Input arguments
@@ -1208,10 +1208,10 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
        ! Dump dynamics variables to history buffers
        call diag_phys_writeout(phys_state(c))
 
-       ! --JH--: Allow advecting of CLDERA clock tendencies if enabled
-       call cldera_clock_tracers_timestep_tend(phys_state(c), ptend(c), ztodt)
+       ! --JH--: Allow advecting of CLDERA passive tendencies if enabled
+       call cldera_passive_tracers_timestep_tend(phys_state(c), ptend(c), ztodt)
        call physics_update(phys_state(c), ptend(c), ztodt, phys_tend(c))
-       call check_tracers_chng(phys_state(c), tracerint, "cldera_clock_tracers_timestep_tend", &
+       call check_tracers_chng(phys_state(c), tracerint, "cldera_passive_tracers_timestep_tend", &
                                nstep, ztodt, dummy_cflx)
         
        ! --JH--: Allow advancing of CLDERA SAI tendencies if enabled
@@ -1482,7 +1482,7 @@ subroutine tphysac (ztodt,   cam_in,  &
     use ionosphere,         only: ionos_intr ! WACCM-X ionosphere
     use tracers,            only: tracers_timestep_tend
     use aoa_tracers,        only: aoa_tracers_timestep_tend
-    use cldera_clock_tracers, only: cldera_clock_tracers_timestep_tend
+    use cldera_passive_tracers, only: cldera_passive_tracers_timestep_tend
     use cldera_sai_tracers, only: cldera_sai_tracers_timestep_tend
     use physconst,          only: rhoh2o, latvap,latice, rga
     use aero_model,         only: aero_model_drydep
@@ -1686,9 +1686,9 @@ if (l_tracer_aero) then
     call check_tracers_chng(state, tracerint, "aoa_tracers_timestep_tend", nstep, ztodt,   &
          cam_in%cflx)
 
-    call cldera_clock_tracers_timestep_tend(state, ptend, ztodt)
+    call cldera_passive_tracers_timestep_tend(state, ptend, ztodt)
     call physics_update(state, ptend, ztodt, tend)
-    call check_tracers_chng(state, tracerint, "cldera_clock_tracers_timestep_tend", nstep, ztodt, &
+    call check_tracers_chng(state, tracerint, "cldera_passive_tracers_timestep_tend", nstep, ztodt, &
                             cam_in%cflx)
     
     call cldera_sai_tracers_timestep_tend(state, ptend, ztodt, ncol)      
@@ -2824,7 +2824,7 @@ subroutine phys_timestep_init(phys_state, cam_out, pbuf2d)
   use radiation,           only: radiation_do
   use tracers,             only: tracers_timestep_init
   use aoa_tracers,         only: aoa_tracers_timestep_init
-  use cldera_clock_tracers,only: cldera_clock_tracers_timestep_init
+  use cldera_passive_tracers,only: cldera_passive_tracers_timestep_init
   use cldera_sai_tracers,  only: cldera_sai_tracers_timestep_init
   use vertical_diffusion,  only: vertical_diffusion_ts_init
   use radheat,             only: radheat_timestep_init
@@ -2916,8 +2916,8 @@ subroutine phys_timestep_init(phys_state, cam_out, pbuf2d)
   ! age of air tracers
   call aoa_tracers_timestep_init(phys_state)
 
-  ! CLDERA clock tracers
-  call cldera_clock_tracers_timestep_init(phys_state)
+  ! CLDERA passive tracers
+  call cldera_passive_tracers_timestep_init(phys_state)
   
   ! CLDERA stratopsheric aerosol injection tracers
   call cldera_sai_tracers_timestep_init(phys_state)

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -1173,7 +1173,6 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
     ! --JH--: adding to allow custom tracer module tendencies
     type(check_tracers_data):: tracerint    ! tracer mass integrals and cummulative boundary fluxes
     real(r8) :: dummy_cflx(pcols, pcnst)    ! array of zeros
-    real(r8) :: dummy_landfrac(pcols)       ! array of zeros
 
     character(len=128)  :: ideal_phys_option
 
@@ -1185,7 +1184,6 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
     nstep = get_nstep()
     zero  = 0._r8
     dummy_cflx = 0._r8
-    dummy_landfrac = 0._r8
 
     ! Associate pointers with physics buffer fields
     if (first_exec_of_phys_run1_adiabatic_or_ideal) then
@@ -2824,7 +2822,6 @@ subroutine phys_timestep_init(phys_state, cam_out, pbuf2d)
   use radiation,           only: radiation_do
   use tracers,             only: tracers_timestep_init
   use aoa_tracers,         only: aoa_tracers_timestep_init
-  use cldera_passive_tracers,only: cldera_passive_tracers_timestep_init
   use cldera_sai_tracers,  only: cldera_sai_tracers_timestep_init
   use vertical_diffusion,  only: vertical_diffusion_ts_init
   use radheat,             only: radheat_timestep_init
@@ -2915,9 +2912,6 @@ subroutine phys_timestep_init(phys_state, cam_out, pbuf2d)
 
   ! age of air tracers
   call aoa_tracers_timestep_init(phys_state)
-
-  ! CLDERA passive tracers
-  call cldera_passive_tracers_timestep_init(phys_state)
   
   ! CLDERA stratopsheric aerosol injection tracers
   call cldera_sai_tracers_timestep_init(phys_state)

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -1209,7 +1209,7 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
        call diag_phys_writeout(phys_state(c))
 
        ! --JH--: Allow advecting of CLDERA passive tendencies if enabled
-       call cldera_passive_tracers_timestep_tend(phys_state(c), ptend(c), ztodt)
+       call cldera_passive_tracers_timestep_tend(phys_state(c), ptend(c), ztodt, dummy_cflx, .false.)
        call physics_update(phys_state(c), ptend(c), ztodt, phys_tend(c))
        call check_tracers_chng(phys_state(c), tracerint, "cldera_passive_tracers_timestep_tend", &
                                nstep, ztodt, dummy_cflx)
@@ -1686,12 +1686,12 @@ if (l_tracer_aero) then
     call check_tracers_chng(state, tracerint, "aoa_tracers_timestep_tend", nstep, ztodt,   &
          cam_in%cflx)
 
-    call cldera_passive_tracers_timestep_tend(state, ptend, ztodt)
+    call cldera_passive_tracers_timestep_tend(state, ptend, ztodt, cam_in%cflx, .true.)
     call physics_update(state, ptend, ztodt, tend)
     call check_tracers_chng(state, tracerint, "cldera_passive_tracers_timestep_tend", nstep, ztodt, &
                             cam_in%cflx)
     
-    call cldera_sai_tracers_timestep_tend(state, ptend, ztodt, ncol)      
+    call cldera_sai_tracers_timestep_tend(state, ptend, ztodt, ncol)
     call physics_update(state, ptend, ztodt, tend)
     call check_tracers_chng(state, tracerint, "cldera_sai_tracers_timestep_tend", nstep, ztodt,   &
          cam_in%cflx)

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -147,6 +147,7 @@ subroutine phys_register
     use sslt_rebin,         only: sslt_rebin_register
     use aoa_tracers,        only: aoa_tracers_register
     use cldera_sai_tracers, only: cldera_sai_tracers_register
+    use cldera_clock_tracers, only: cldera_clock_tracers_register
     use aircraft_emit,      only: aircraft_emit_register
     use cam_diagnostics,    only: diag_register
     use cloud_diagnostics,  only: cloud_diagnostics_register
@@ -316,6 +317,9 @@ subroutine phys_register
 
     ! Register age of air tracers
     call aoa_tracers_register()
+
+    ! Register CLDERA clock tracers
+    call cldera_clock_tracers_register()
     
     ! Register CLDERA stratospheric aerosol injection tracers
     call cldera_sai_tracers_register()
@@ -713,6 +717,7 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
     use tracers,            only: tracers_init
     use aoa_tracers,        only: aoa_tracers_init
     use cldera_sai_tracers, only: cldera_sai_tracers_init
+    use cldera_clock_tracers, only: cldera_clock_tracers_init
     use rayleigh_friction,  only: rayleigh_friction_init
     use pbl_utils,          only: pbl_utils_init
     use vertical_diffusion, only: vertical_diffusion_init
@@ -782,6 +787,9 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
 
     ! age of air tracers
     call aoa_tracers_init()
+
+    ! CLDERA clock tracers
+    call cldera_clock_tracers_init()
     
     ! CLDERA stratospheric aerosol injection tracers
     call cldera_sai_tracers_init()
@@ -1131,7 +1139,8 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
     use aoa_tracers,     only: aoa_tracers_timestep_tend
     use ppgrid,          only: pcols
     use constituents,    only: pcnst
-    use cldera_sai_tracers,     only: cldera_sai_tracers_timestep_tend
+    use cldera_sai_tracers,   only: cldera_sai_tracers_timestep_tend
+    use cldera_clock_tracers, only: cldera_clock_tracers_timestep_tend
 
     !
     ! Input arguments
@@ -1175,6 +1184,8 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
 
     nstep = get_nstep()
     zero  = 0._r8
+    dummy_cflx = 0._r8
+    dummy_landfrac = 0._r8
 
     ! Associate pointers with physics buffer fields
     if (first_exec_of_phys_run1_adiabatic_or_ideal) then
@@ -1196,9 +1207,14 @@ subroutine phys_run1_adiabatic_or_ideal(ztodt, phys_state, phys_tend,  pbuf2d)
 
        ! Dump dynamics variables to history buffers
        call diag_phys_writeout(phys_state(c))
+
+       ! --JH--: Allow advecting of CLDERA clock tendencies if enabled
+       call cldera_clock_tracers_timestep_tend(phys_state(c), ptend(c), ztodt)
+       call physics_update(phys_state(c), ptend(c), ztodt, phys_tend(c))
+       call check_tracers_chng(phys_state(c), tracerint, "cldera_clock_tracers_timestep_tend", &
+                               nstep, ztodt, dummy_cflx)
         
        ! --JH--: Allow advancing of CLDERA SAI tendencies if enabled
-       ! the timestep_tend function automatically checks that aoa tracers are enabled for the run
        call cldera_sai_tracers_timestep_tend(phys_state(c), ptend(c), ztodt, phys_state(c)%ncol) 
        call physics_update(phys_state(c), ptend(c), ztodt, phys_tend(c))
        call check_tracers_chng(phys_state(c),tracerint,"cldera_sai_tracers_timestep_tend",nstep,&
@@ -1466,6 +1482,7 @@ subroutine tphysac (ztodt,   cam_in,  &
     use ionosphere,         only: ionos_intr ! WACCM-X ionosphere
     use tracers,            only: tracers_timestep_tend
     use aoa_tracers,        only: aoa_tracers_timestep_tend
+    use cldera_clock_tracers, only: cldera_clock_tracers_timestep_tend
     use cldera_sai_tracers, only: cldera_sai_tracers_timestep_tend
     use physconst,          only: rhoh2o, latvap,latice, rga
     use aero_model,         only: aero_model_drydep
@@ -1668,6 +1685,11 @@ if (l_tracer_aero) then
     call physics_update(state, ptend, ztodt, tend)
     call check_tracers_chng(state, tracerint, "aoa_tracers_timestep_tend", nstep, ztodt,   &
          cam_in%cflx)
+
+    call cldera_clock_tracers_timestep_tend(state, ptend, ztodt)
+    call physics_update(state, ptend, ztodt, tend)
+    call check_tracers_chng(state, tracerint, "cldera_clock_tracers_timestep_tend", nstep, ztodt, &
+                            cam_in%cflx)
     
     call cldera_sai_tracers_timestep_tend(state, ptend, ztodt, ncol)      
     call physics_update(state, ptend, ztodt, tend)
@@ -2802,6 +2824,7 @@ subroutine phys_timestep_init(phys_state, cam_out, pbuf2d)
   use radiation,           only: radiation_do
   use tracers,             only: tracers_timestep_init
   use aoa_tracers,         only: aoa_tracers_timestep_init
+  use cldera_clock_tracers,only: cldera_clock_tracers_timestep_init
   use cldera_sai_tracers,  only: cldera_sai_tracers_timestep_init
   use vertical_diffusion,  only: vertical_diffusion_ts_init
   use radheat,             only: radheat_timestep_init
@@ -2892,6 +2915,9 @@ subroutine phys_timestep_init(phys_state, cam_out, pbuf2d)
 
   ! age of air tracers
   call aoa_tracers_timestep_init(phys_state)
+
+  ! CLDERA clock tracers
+  call cldera_clock_tracers_timestep_init(phys_state)
   
   ! CLDERA stratopsheric aerosol injection tracers
   call cldera_sai_tracers_timestep_init(phys_state)


### PR DESCRIPTION
Merging tracer module containing AOA, E90, ST80 implementations. All are evolved via the tendencies computed in `components/eam/src/physics/cam/cldera_passive_tracers.F90`. The output fields for the E90, ST80 tracers are `E90j` and `ST80_25j` to differentiate from the chemistry (Allen's) implementation.