### PR TITLE
changed 20TR_eam_CMIP6 use case to use the SO2 emissions file that go…

### DIFF
--- a/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_eam_CMIP6.xml
@@ -39,7 +39,7 @@
 <so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc </so4_a1_ext_file>
 <so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc </so4_a2_ext_file>
 <!-- CLDERA merged volcanic emission files -->
-<so2_ext_file  cldera_strat_volc="1">atm/cldera/emissions/volc/merge_cmip6_and_volc_so2/merged_cmip6_and_VolcanEESMv3.11_1850-1999_180x360_c20220808.nc </so2_ext_file>
+<so2_ext_file  cldera_strat_volc="1">atm/cldera/emissions/volc/merge_cmip6_and_volc_so2/merged_cmip6_and_VolcanEESMv3.11_1850-2014_180x360_c20221019.nc </so2_ext_file>
 
 <!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
 <srf_emis_type>INTERP_MISSING_MONTHS</srf_emis_type>


### PR DESCRIPTION
Changed the default SO2 emissions file for the 2OTR_eam_CMIP6 use case. The new file: `/atm/cldera/emissions/volc/merge_cmip6_and_volc_so2/merged_cmip6_and_VolcanEESMv3.11_1850-2014_180x360_c20221019.nc` runs through 2014 instead of ending at Jan 1 2000. 
Note this only works on Sandia HPC for now because we don't want to write to DIN_LOC_ROOT on other platforms. User will have to specify the file in their runscript on other platforms. 