### PR TITLE
Add WACCM-style E90 and ST80 via chemistry mods

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -2878,11 +2878,10 @@ if ($chem eq 'linoz_mam4_resus_mom' || $chem eq 'linoz_mam4_resus_mom_soag') {
 
     my %species;
 
-    # Surface emission datasets (AH -- added E90 here):
+    # Surface emission datasets:
     %species = ();
     if ($chem eq 'linoz_mam4_resus_mom_soag') {
 	%species = ('DMS       -> ' => 'dms_emis_file',
-                    'E90       -> ' => 'E90_emis_file',
 		    'SO2       -> ' => 'so2_emis_file',
 		    'bc_a4     -> ' => 'bc_a4_emis_file',
 		    'pom_a4    -> ' => 'pom_a4_emis_file',
@@ -2894,7 +2893,6 @@ if ($chem eq 'linoz_mam4_resus_mom' || $chem eq 'linoz_mam4_resus_mom_soag') {
 	    );
     } else {
 	%species = ('DMS       -> ' => 'dms_emis_file',
-                    'E90       -> ' => 'E90_emis_file',
 		    'SO2       -> ' => 'so2_emis_file',
 		    'SOAG      -> ' => 'soag_emis_file',
 		    'bc_a4     -> ' => 'bc_a4_emis_file',
@@ -2906,6 +2904,11 @@ if ($chem eq 'linoz_mam4_resus_mom' || $chem eq 'linoz_mam4_resus_mom_soag') {
 		    'num_a4    -> ' => 'mam7_num_a3_emis_file',
 	    );
     }
+    # Add E90 to hashes
+    if ($cfg->get('cldera_chem_tracers')) {
+        %species = (%species, 'E90       -> ' => 'E90_emis_file');
+    }
+
     my %verhash = ('ver'=>'mam');
     my $first = 1;
     my $pre = "";

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -2878,10 +2878,11 @@ if ($chem eq 'linoz_mam4_resus_mom' || $chem eq 'linoz_mam4_resus_mom_soag') {
 
     my %species;
 
-    # Surface emission datasets:
+    # Surface emission datasets (AH -- added E90 here):
     %species = ();
     if ($chem eq 'linoz_mam4_resus_mom_soag') {
 	%species = ('DMS       -> ' => 'dms_emis_file',
+                    'E90       -> ' => 'E90_emis_file',
 		    'SO2       -> ' => 'so2_emis_file',
 		    'bc_a4     -> ' => 'bc_a4_emis_file',
 		    'pom_a4    -> ' => 'pom_a4_emis_file',
@@ -2893,6 +2894,7 @@ if ($chem eq 'linoz_mam4_resus_mom' || $chem eq 'linoz_mam4_resus_mom_soag') {
 	    );
     } else {
 	%species = ('DMS       -> ' => 'dms_emis_file',
+                    'E90       -> ' => 'E90_emis_file',
 		    'SO2       -> ' => 'so2_emis_file',
 		    'SOAG      -> ' => 'soag_emis_file',
 		    'bc_a4     -> ' => 'bc_a4_emis_file',

--- a/components/eam/bld/config_files/definition.xml
+++ b/components/eam/bld/config_files/definition.xml
@@ -41,6 +41,9 @@ Switch to turn on FV offline driver: 0 => no, 1 => yes.
 <entry id="waccmx" valid_values="0,1" value="0">
 Option to turn on waccmx thermosphere/ionosphere extension: 0 => no, 1 => yes
 </entry>
+<entry id="cldera_chem_tracers" valid_values="0,1" value="0">
+Option to turn on WACCM-style E90/ST80 tracers: 0 => off, 1 => yes
+</entry>
 <entry id="phys" valid_values="cam3,cam3_5_1,cam4,cam5,ideal,adiabatic,default" value="">
 Physics package: cam3, cam4, cam5, ideal (Held-Suarez forcings), adiabatic, default (eam).
 </entry>

--- a/components/eam/bld/configure
+++ b/components/eam/bld/configure
@@ -161,6 +161,7 @@ OPTIONS
                         The user does not need to set this if one of the waccm chemistry options
                         is chosen.
      -waccmx            Build EAM/WACCM with WACCM upper Thermosphere/Ionosphere extended package
+     -cldera_chem_tracers Build with WACCM-style E90/ST80 tracers. Will also need to pass -usr_mech_infile
 
 
   Options relevent to SCAM mode:
@@ -372,6 +373,7 @@ GetOptions(
     "waccm_phys"                => \$opts{'waccm_phys'},
     "offline_dyn"               => \$opts{'offline_dyn'},
     "waccmx"                    => \$opts{'waccmx'},
+    "cldera_chem_tracers"       => \$opts{'cldera_chem_tracers'},
     "cosp_libdir=s"             => \$opts{'cosp_libdir'},
     "esmf_libdir=s"             => \$opts{'esmf_libdir'},
     "mct_libdir=s"              => \$opts{'mct_libdir'},

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -27,6 +27,9 @@ module mo_gas_phase_chemdr
   integer :: ndx_cldfr, ndx_cmfdqr, ndx_nevapr, ndx_cldtop, ndx_prain, ndx_sadsulf
   integer :: ndx_h2so4
   integer :: inv_ndx_cnst_o3, inv_ndx_m
+!AH
+  integer :: st80_25_ndx
+  integer :: st80_25_tau_ndx
 
   character(len=fieldname_len),dimension(rxntot-phtcnt) :: rxn_names
   character(len=fieldname_len),dimension(phtcnt)        :: pht_names
@@ -63,6 +66,9 @@ contains
          convproc_do_aer_out = convproc_do_aer ) 
    
     ndx_h2so4 = get_spc_ndx('H2SO4')
+!AH
+    st80_25_ndx     = get_spc_ndx   ('ST80_25')
+    st80_25_tau_ndx = get_rxt_ndx   ('ST80_25_tau')
 
     het1_ndx= get_rxt_ndx('het1')
     o3_ndx  = get_spc_ndx('O3')
@@ -449,7 +455,14 @@ contains
     !-----------------------------------------------------------------------      
     !        ... Xform from mmr to vmr
     !-----------------------------------------------------------------------      
-    call mmr2vmr( mmr, vmr, mbar, ncol )
+!    call mmr2vmr( mmr, vmr, mbar, ncol )
+!AH -- added ST80
+    call mmr2vmr( mmr(:ncol,:,:), vmr(:ncol,:,:), mbar(:ncol,:), ncol )
+    if ( st80_25_ndx > 0 ) then
+       where ( pmid(:ncol,:) < 80.e+2_r8 )
+          vmr(:ncol,:,st80_25_ndx) = 200.e-9_r8
+       end where
+    end if
 
     if (h2o_ndx>0) then
        !-----------------------------------------------------------------------      

--- a/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
+++ b/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90
@@ -27,9 +27,7 @@ module mo_gas_phase_chemdr
   integer :: ndx_cldfr, ndx_cmfdqr, ndx_nevapr, ndx_cldtop, ndx_prain, ndx_sadsulf
   integer :: ndx_h2so4
   integer :: inv_ndx_cnst_o3, inv_ndx_m
-!AH
   integer :: st80_25_ndx
-  integer :: st80_25_tau_ndx
 
   character(len=fieldname_len),dimension(rxntot-phtcnt) :: rxn_names
   character(len=fieldname_len),dimension(phtcnt)        :: pht_names
@@ -66,9 +64,7 @@ contains
          convproc_do_aer_out = convproc_do_aer ) 
    
     ndx_h2so4 = get_spc_ndx('H2SO4')
-!AH
-    st80_25_ndx     = get_spc_ndx   ('ST80_25')
-    st80_25_tau_ndx = get_rxt_ndx   ('ST80_25_tau')
+    st80_25_ndx = get_spc_ndx('ST80_25')
 
     het1_ndx= get_rxt_ndx('het1')
     o3_ndx  = get_spc_ndx('O3')
@@ -455,9 +451,7 @@ contains
     !-----------------------------------------------------------------------      
     !        ... Xform from mmr to vmr
     !-----------------------------------------------------------------------      
-!    call mmr2vmr( mmr, vmr, mbar, ncol )
-!AH -- added ST80
-    call mmr2vmr( mmr(:ncol,:,:), vmr(:ncol,:,:), mbar(:ncol,:), ncol )
+    call mmr2vmr( mmr, vmr, mbar, ncol )
     if ( st80_25_ndx > 0 ) then
        where ( pmid(:ncol,:) < 80.e+2_r8 )
           vmr(:ncol,:,st80_25_ndx) = 200.e-9_r8

--- a/components/eam/src/chemistry/pp_linoz_mam4_resus_mom_soag/chem_mech.in
+++ b/components/eam/src/chemistry/pp_linoz_mam4_resus_mom_soag/chem_mech.in
@@ -1,6 +1,7 @@
    SPECIES
-
+*AH -- added E90
       Solution
+ E90 -> CO
  O3
  H2O2, H2SO4, SO2, DMS -> CH3SCH3, SOAG -> C
  so4_a1 -> NH4HSO4
@@ -33,10 +34,11 @@
       End Col-int
 
    End SPECIES
-
+*AH -- Added E90
    Solution Classes
       Explicit
         O3
+        E90
       End Explicit
       Implicit
         H2O2, H2SO4, SO2, DMS, SOAG
@@ -55,7 +57,7 @@
       Photolysis
  [jh2o2]    H2O2 + hv ->
       End Photolysis
-
+*AH -- added E90
       Reactions
  [usr_HO2_HO2] HO2 + HO2 -> H2O2
                H2O2 + OH -> H2O + HO2                                           ; 2.9e-12, -160
@@ -63,6 +65,7 @@
                DMS + OH -> SO2                                                  ; 9.6e-12, -234.
  [usr_DMS_OH]  DMS + OH -> .5 * SO2 + .5 * HO2
                DMS + NO3 -> SO2 + HNO3                                          ; 1.9e-13,  520.
+ [E90_tau]     E90 -> sink                                                      ; 1.29e-07
       End Reactions
 
       Ext Forcing

--- a/components/eam/src/chemistry/pp_linoz_mam4_resus_mom_soag/chem_mech.in
+++ b/components/eam/src/chemistry/pp_linoz_mam4_resus_mom_soag/chem_mech.in
@@ -1,7 +1,6 @@
    SPECIES
-*AH -- added E90
+
       Solution
- E90 -> CO
  O3
  H2O2, H2SO4, SO2, DMS -> CH3SCH3, SOAG -> C
  so4_a1 -> NH4HSO4
@@ -34,11 +33,10 @@
       End Col-int
 
    End SPECIES
-*AH -- Added E90
+
    Solution Classes
       Explicit
         O3
-        E90
       End Explicit
       Implicit
         H2O2, H2SO4, SO2, DMS, SOAG
@@ -57,7 +55,7 @@
       Photolysis
  [jh2o2]    H2O2 + hv ->
       End Photolysis
-*AH -- added E90
+
       Reactions
  [usr_HO2_HO2] HO2 + HO2 -> H2O2
                H2O2 + OH -> H2O + HO2                                           ; 2.9e-12, -160
@@ -65,7 +63,6 @@
                DMS + OH -> SO2                                                  ; 9.6e-12, -234.
  [usr_DMS_OH]  DMS + OH -> .5 * SO2 + .5 * HO2
                DMS + NO3 -> SO2 + HNO3                                          ; 1.9e-13,  520.
- [E90_tau]     E90 -> sink                                                      ; 1.29e-07
       End Reactions
 
       Ext Forcing


### PR DESCRIPTION
Second try to add E90 and ST80 in same manner as CESM did for WACCM, following Allen's mods. This adds a configure flag to enable and would require passing a custom `chem_mech.in` file with the "reaction rates" for E90/ST80 defined, which would then trigger the chemistry pre-processor to be run at case setup/build time. While a little cumbersome, this leaves the existing model behavior and code mostly unchanged. An alternative to this approach was to run the chemistry preprocessor offline, and then copy in all of the modified source files to overwrite the current chemistry source. This resulted in a very large PR, that also was not building/running. The present PR offers a lighter-weight alternative that will allow us to at least run with the additions of E90 and ST80 via mostly runscript changes.

[BFB]