### PR TITLE
Remove diagnostic PV from inithist write

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -495,7 +495,7 @@ _TESTS = {
             "ERS_Ln9.ne4pg2_oQU480.F20TR.eam-cldera_strat_volc",
             "ERS_Ln9.ne4pg2_oQU480.F20TR-CLDERA.eam-prognostic_volcaero",
             "SMS_D_Ln9.ne4pg2_ne4pg2.F20TR-CICE.eam-prognostic_volcaero",
-            "SMS.ne4_ne4.FIDEAL",
+            "SMS.ne4_ne4.FIDEAL.eam-inithist",
             )
     },
 

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/inithist/user_nl_eam
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/inithist/user_nl_eam
@@ -1,0 +1,1 @@
+inithist = 'ENDOFRUN'

--- a/components/eam/src/dynamics/se/dp_coupling.F90
+++ b/components/eam/src/dynamics/se/dp_coupling.F90
@@ -317,8 +317,6 @@ CONTAINS
           call outfld('V&IC', elem(ie)%state%V(:,:,2,:,tl_f), ncol_d,ie)
           call get_temperature(elem(ie),temperature,hvcoord,tl_f)
           call outfld('T&IC',temperature,ncol_d,ie)
-          call get_pot_vort(elem(ie),potvort,hvcoord,tl_f)
-          call outfld('PV&IC',potvort,ncol_d,ie)
           do m = 1,pcnst
             call outfld(trim(cnst_name(m))//'&IC',elem(ie)%state%Q(:,:,:,m), ncol_d,ie)
           end do ! m
@@ -331,7 +329,6 @@ CONTAINS
           call outfld('U&IC', phys_state(lchnk)%u, pcols,lchnk)
           call outfld('V&IC', phys_state(lchnk)%v, pcols,lchnk)
           call outfld('PS&IC',phys_state(lchnk)%ps,pcols,lchnk)
-          call outfld('PV&IC',phys_state(lchnk)%pv,pcols,lchnk)
           do m = 1,pcnst
             call outfld(trim(cnst_name(m))//'&IC',phys_state(lchnk)%q(1,1,m), pcols,lchnk)
           end do ! m


### PR DESCRIPTION
Remove diagnostic potential vorticity from inithist write. Since this quantity is entirely diagnostic in this implementation, it should not need to be read from the initial condition to initialize the model, hence we have no need to write it to the initial condition. This was introduced in PR #25 and resulted in a runtime error when trying to write an initial condition (issue #34). This PR is BFB,  but requires a baseline bless because it changes the name of the FIDEAL test to use a testmod to change inithist.

Fixes #34 

[BFB]