### PR TITLE
CLDERA: move call to cldera_compute_stats

### DIFF
--- a/components/eam/src/control/cam_comp.F90
+++ b/components/eam/src/control/cam_comp.F90
@@ -471,14 +471,20 @@ subroutine cam_run1(cam_in, cam_out)
 #if ( defined SPMD )
    use mpishorthand,     only: mpicom
 #endif
-   use time_manager,     only: get_nstep
+   use time_manager,     only: get_nstep, get_curr_date
    use scamMod,          only: single_column
+#if defined(CLDERA_PROFILING)
+    use cldera_interface_mod, only: cldera_compute_stats
+#endif
 
    type(cam_in_t)  :: cam_in(begchunk:endchunk)
    type(cam_out_t) :: cam_out(begchunk:endchunk)
 
 #if ( defined SPMD )
    real(r8) :: mpi_wtime
+#endif
+#if defined(CLDERA_PROFILING)
+    integer :: ymd, yr, mon, day, tod
 #endif
 !-----------------------------------------------------------------------
 
@@ -501,6 +507,17 @@ subroutine cam_run1(cam_in, cam_out)
    if (single_column) then
      call scam_use_iop_srf( cam_in)
    endif
+
+#if defined(CLDERA_PROFILING)
+   ! Compute stats here, since the first thing that happens in phys_run1 is the
+   ! writing of the physics state (possibly after some checks/setup, but nothing
+   ! that should change the values of state vars)
+   call get_curr_date( yr, mon, day, tod)
+   ymd = yr*10000 + mon*100 + day
+   call t_startf('cldera_compute_stats')
+   call cldera_compute_stats(ymd,tod)
+   call t_stopf('cldera_compute_stats')
+#endif
 
    !
    !----------------------------------------------------------

--- a/components/eam/src/cpl/atm_comp_mct.F90
+++ b/components/eam/src/cpl/atm_comp_mct.F90
@@ -483,9 +483,6 @@ CONTAINS
     use pmgrid,          only: plev, plevp
     use constituents,    only: pcnst
     use shr_sys_mod,     only: shr_sys_flush
-#if defined(CLDERA_PROFILING)
-    use cldera_interface_mod, only: cldera_compute_stats
-#endif
 
     ! 
     ! Arguments
@@ -672,12 +669,6 @@ CONTAINS
       call memmon_dump_fort('memmon.out',SubName //':end::',lbnum)
       call memmon_reset_addr()
     endif
-#endif
-
-#if defined(CLDERA_PROFILING)
-    call t_startf('cldera_compute_stats')
-    call cldera_compute_stats(ymd,tod)
-    call t_stopf('cldera_compute_stats')
 #endif
 
   end subroutine atm_run_mct


### PR DESCRIPTION
The new location *should* be compatible with when EAM takes a snapshot of its physics state for output. It's not _the same_, since EAM does the output "one column chunk at a time", but nothing should happen between the two locations that could alter the physics state. So for all practical purposes, the new location where we call `cldera_compute_stats` _is_ the same as the location where EAM calls outfld (meaning that the two should produce the same output).

I'm going to test this on a small case on mappy, comparing cldera fields to EAM output.