### PR TITLE
CLDERA: fix AOD cldera fields declaration

### DIFF
--- a/components/eam/src/control/cam_comp.F90
+++ b/components/eam/src/control/cam_comp.F90
@@ -318,6 +318,12 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    call cldera_add_partitioned_field("psdry",1,dims,dimnames,nparts,part_dim)
    call cldera_add_partitioned_field("phis",1,dims,dimnames,nparts,part_dim)
 
+   ! Last arg is view=false, since AOD fields are *not* views of EAM persistent data.
+   call cldera_add_partitioned_field("aod"    , 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("aod_so2", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("aod_ash", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("aod_sulf",1,dims,dimnames,nparts,part_dim,.false.)
+
    !2d, mid points
    dims(2) = pver
    dimnames(2) = 'lev'
@@ -332,12 +338,6 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    call cldera_add_partitioned_field("pdel_dry",2,dims,dimnames,nparts,part_dim)
    call cldera_add_partitioned_field("exner",2,dims,dimnames,nparts,part_dim)
    call cldera_add_partitioned_field("zm",2,dims,dimnames,nparts,part_dim)
-
-   ! Last arg is view=false, since AOD fields are *not* views of EAM persistent data.
-   call cldera_add_partitioned_field("aod"    , 2,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("aod_so2", 2,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("aod_ash", 2,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("aod_sulf",2,dims,dimnames,nparts,part_dim,.false.)
 
    ! 2d, interfaces
    dims(2) = pver+1


### PR DESCRIPTION
They are no longer defined over vertical levels, only over colums (at surface)