### PR TITLE
CLDERA: Moved profiling testmods, and fixed shell_commands

### DIFF
--- a/components/eam/cime_config/testdefs/testmods_dirs/cldera/profiling/basic_so2_h2so4/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/cldera/profiling/basic_so2_h2so4/shell_commands
@@ -1,2 +1,0 @@
-RUNDIR=$(./xmlquery --value RUNDIR)
-cp ${CLDERA_PATH}/share/profile_so2_h2so4.yaml ${RUNDIR}/cldera_profiling_config.yaml

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/cldera/profiling/basic_so2_h2so4/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/cldera/profiling/basic_so2_h2so4/shell_commands
@@ -1,0 +1,11 @@
+RUNDIR=$(./xmlquery --value RUNDIR)
+mkdir ${RUNDIR}
+CLDERA_PATH=$(python -c "
+import xml.etree.ElementTree as ET
+with open('./env_mach_specific.xml','r') as fd:
+  tree = ET.parse(fd).getroot()
+  env_vars = tree.find('environment_variables')
+  cldera_path = [e.text for e in env_vars if e.attrib['name']=='CLDERA_PATH']
+  print (cldera_path[0])
+")
+cp ${CLDERA_PATH}/share/cldera_profiling_config.yaml ${RUNDIR}/cldera_profiling_config.yaml


### PR DESCRIPTION
Fix location of profilng testmod, and fix also content of shell_commands, since it's run before env_mach_specific.sh is loaded (or even created).

This is a bit hacky, but works.

Fixes #45 