### PR TITLE
CLDERA: add a test that uses the profiling test mod

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -496,6 +496,7 @@ _TESTS = {
             "ERS_Ln9.ne4pg2_oQU480.F20TR-CLDERA.eam-prognostic_volcaero",
             "SMS_D_Ln9.ne4pg2_ne4pg2.F20TR-CICE.eam-prognostic_volcaero",
             "SMS.ne4_ne4.FIDEAL.eam-inithist",
+            "SMS.ne4_ne4.FIDEAL.eam-cldera-profiling-basic_so2_h2so4",
             )
     },
 

--- a/components/eam/cime_config/testdefs/testmods_dirs/eam/cldera/profiling/basic_so2_h2so4/shell_commands
+++ b/components/eam/cime_config/testdefs/testmods_dirs/eam/cldera/profiling/basic_so2_h2so4/shell_commands
@@ -1,3 +1,4 @@
+./xmlchange --append CAM_CONFIG_OPTS="-cldera_profiling -cldera_sai_trcs"
 RUNDIR=$(./xmlquery --value RUNDIR)
 mkdir ${RUNDIR}
 CLDERA_PATH=$(python -c "


### PR DESCRIPTION
Now that #46 was merged, we can use the profiling testmod. This way we can actually test the profiling tool as part of our nightlies.

Also, fix the shell commands to add profiling and sai trcs to cam config options.