### PR TITLE
CLDERA: avoid tracking non-persistent pbuf quantities

### DIFF
--- a/components/eam/src/control/cam_comp.F90
+++ b/components/eam/src/control/cam_comp.F90
@@ -106,7 +106,8 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
                                    cldera_commit_field
    use physics_buffer,   only: physics_buffer_desc, col_type_grid, pbuf_get_index, &
                                pbuf_get_field_rank, pbuf_get_field_dims, pbuf_get_field, &
-                               pbuf_get_field_name, pbuf_has_field
+                               pbuf_get_field_name, pbuf_has_field, pbuf_get_field_persistence, &
+                               persistence_global
    use ppgrid,           only: begchunk, endchunk, pcols, pver
    use phys_grid,        only: get_ncols_p, get_gcol_all_p, get_area_all_p
    use constituents,     only: pcnst, cnst_name
@@ -265,6 +266,11 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    do idx=1,nfields
      ! retrieve fields
      fname = pbuf_get_field_name(idx)
+
+     ! We can only track persistent pbuf quantities
+     if (pbuf_get_field_persistence(fname) .ne. persistence_global) then
+       cycle
+     endif
 
      ! retrieve field specs
      field_desc => pbuf2d(idx,begchunk)

--- a/components/eam/src/control/cam_comp.F90
+++ b/components/eam/src/control/cam_comp.F90
@@ -141,7 +141,7 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
 #if defined(CLDERA_PROFILING)
    character(len=max_str_len) :: fname
    integer :: c, nfields, idx, rank, icmp, nparts, part_dim, ipart, fsize, ncols
-   integer :: nlcols
+   integer :: nlcols,irank
    integer :: dims(3)
    integer, allocatable :: cols_gids(:)
    real(r8), allocatable :: cols_area(:)
@@ -149,6 +149,7 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    logical :: in_pbuf, in_q
    real(r8), pointer :: field1d(:), field2d(:,:), field3d(:,:,:)
    type(physics_buffer_desc), pointer :: field_desc
+   character(len=5) :: int_str
 #endif
    !-----------------------------------------------------------------------
    etamid = nan
@@ -279,7 +280,16 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
      dims(:) = pbuf_get_field_dims(idx)
      dims(1) = nlcols
 
-     dimnames(2) = "lev"
+     do irank=2,rank
+       if (dims(irank) .eq. plev) then
+         dimnames(irank) = "lev"
+       elseif (dims(irank) .eq. (plev+1)) then
+         dimnames(irank) = "ilev"
+       else
+         write (int_str,"(I5)") dims(irank)
+         dimnames(irank) = "dim"//trim(adjustl(int_str))
+       endif
+     enddo
 
      call cldera_add_partitioned_field(fname,2,dims,dimnames,nparts,part_dim)
      do ipart = 1,nparts

--- a/components/eam/src/physics/cam/physics_buffer.F90.in
+++ b/components/eam/src/physics/cam/physics_buffer.F90.in
@@ -140,6 +140,7 @@ module physics_buffer
             pbuf_init_restart,    &
             pbuf_write_restart,   &
             pbuf_read_restart,    &
+            pbuf_get_field_persistence, &
             dtype_r8, dtype_r4, dtype_i4
 
    integer, public :: dyn_time_lvls  ! number of time levels in physics buffer (dycore dependent)
@@ -256,6 +257,24 @@ CONTAINS
        hdr=>hdr%nexthdr
     end do
   end function pbuf_has_field
+
+  function pbuf_get_field_persistence(fname) result(persistence)
+    character(len=16) :: fname
+    integer :: persistence
+
+    type(physics_buffer_hdr), pointer :: hdr
+
+    hdr => hdrbuffertop
+
+    do while (associated(hdr))
+       if (trim(hdr%name) == trim(fname)) then
+         persistence = hdr%persistence
+         exit
+       endif
+       hdr=>hdr%nexthdr
+    end do
+    persistence = -1
+  end function pbuf_get_field_persistence
 
   function pbuf_get_field_name(index)
     integer, intent(in) :: index


### PR DESCRIPTION
Namely:

* do not grab fields that are not persistent: non-persistent fields will (or can) be deallocated at the end of each physpkg call, making the pointers invalid
* provide dimnames that are based on the field extents. This should fix an issue in cldera-tools related to "lev" being registered as of length 72 first and 73 later.