### PR TITLE
Add ability of cldera-profiling to handle restarts

### DIFF
--- a/components/eam/src/cpl/atm_comp_mct.F90
+++ b/components/eam/src/cpl/atm_comp_mct.F90
@@ -145,6 +145,8 @@ CONTAINS
     integer :: tod              ! CAM current time of day (sec)
     integer :: start_ymd        ! Start date (YYYYMMDD)
     integer :: start_tod        ! Start time of day (sec)
+    integer :: curr_ymd         ! Current date (YYYYMMDD)
+    integer :: curr_tod         ! Current time of day (sec)
     integer :: ref_ymd          ! Reference date (YYYYMMDD)
     integer :: ref_tod          ! Reference time of day (sec)
     integer :: stop_ymd         ! Stop date (YYYYMMDD)
@@ -287,6 +289,7 @@ CONTAINS
        call seq_timemgr_EClockGetData(EClock, &
             start_ymd=start_ymd, start_tod=start_tod, &
             ref_ymd=ref_ymd, ref_tod=ref_tod,         &
+            curr_ymd=curr_ymd, curr_tod=curr_tod,         &
             stop_ymd=stop_ymd, stop_tod=stop_tod,     &
             calendar=calendar )
        !
@@ -314,7 +317,7 @@ CONTAINS
        ! we'll try to register stuff in cldera, and if cldera is not inited,
        ! all registration calls will return immediately
        call t_startf('cldera_init')
-       call cldera_init(mpicom_atm,start_ymd,start_tod,stop_ymd,stop_tod)
+       call cldera_init(mpicom_atm,start_ymd,start_tod,curr_ymd,curr_tod,stop_ymd,stop_tod)
        call cldera_set_log_unit (iulog)
        call cldera_set_masterproc (masterproc)
        call t_stopf('cldera_init')

--- a/components/eam/src/cpl/atm_comp_mct.F90
+++ b/components/eam/src/cpl/atm_comp_mct.F90
@@ -486,6 +486,7 @@ CONTAINS
     use pmgrid,          only: plev, plevp
     use constituents,    only: pcnst
     use shr_sys_mod,     only: shr_sys_flush
+    use physpkg,         only: is_atm_init
 
     ! 
     ! Arguments
@@ -528,6 +529,7 @@ CONTAINS
     character(len=*), parameter :: subname="atm_run_mct"
     !-----------------------------------------------------------------------
 
+    is_atm_init = .false.
 #if (defined _MEMTRACE)
     if(masterproc) then
       lbnum=1


### PR DESCRIPTION
This PR does two things:

1. add ability for cldera profiling to handle restarts: append to cldera_stats.nc instead of nuking it
2. fix an issue having to do with EAM's first timestep (see E3SM-Project#5904)

I manually ran a FIDEAL testcase, and verified that running 2 steps or running 1+1 steps (with restart) produces the same cldera_stats.nc file.