### PR TITLE
Add additional cldera-tools hooks

### DIFF
--- a/components/eam/src/chemistry/mozart/mo_chm_diags.F90
+++ b/components/eam/src/chemistry/mozart/mo_chm_diags.F90
@@ -758,13 +758,13 @@ contains
     endif
 
 #if defined(CLDERA_PROFILING)
-    call cldera_set_field_part_data("Mass_so4" ,lchnk-begchunk+1,mass_so4(:ncol,:,:))
-
-    ! Only three tags needed for now
-    if (nso4>2) then
-       do tag_loop = 1,3
+    if (nso4>1) then
+       do tag_loop = 1,nso4
+          if (tag_loop>3) exit ! Only three tags needed for now
           call cldera_set_field_part_data("Mass_so4"//tagged_suffix(tag_loop),lchnk-begchunk+1,mass_so4(:ncol,:,tag_loop))
        end do
+    else
+       call cldera_set_field_part_data("Mass_so4" ,lchnk-begchunk+1,mass_so4(:ncol,:,:))
     end if
 #endif
 #endif

--- a/components/eam/src/chemistry/mozart/mo_chm_diags.F90
+++ b/components/eam/src/chemistry/mozart/mo_chm_diags.F90
@@ -11,6 +11,10 @@ module mo_chm_diags
   use mo_jeuv,      only : neuv
   use modal_aero_data,only: nso4, nbc, npoa, nsoa
   use cam_logfile,    only: iulog
+#if defined(CLDERA_PROFILING)
+  use ppgrid,         only: begchunk
+  use cldera_interface_mod, only: cldera_set_field_part_data
+#endif
 
   private
 
@@ -752,6 +756,17 @@ contains
        call outfld( 'Mass_soa', mass_soa(:ncol,:,:),ncol,lchnk)
     end if
     endif
+
+#if defined(CLDERA_PROFILING)
+    call cldera_set_field_part_data("Mass_so4" ,lchnk-begchunk+1,mass_so4(:ncol,:,:))
+
+    ! Only three tags needed for now
+    if (nso4>2) then
+       do tag_loop = 1,3
+          call cldera_set_field_part_data("Mass_so4"//tagged_suffix(tag_loop),lchnk-begchunk+1,mass_so4(:ncol,:,tag_loop))
+       end do
+    end if
+#endif
 #endif
 
     call outfld( 'NOX',  vmr_nox(:ncol,:),  ncol, lchnk )

--- a/components/eam/src/control/cam_comp.F90
+++ b/components/eam/src/control/cam_comp.F90
@@ -336,11 +336,23 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    call cldera_add_partitioned_field("psdry",1,dims,dimnames,nparts,part_dim)
    call cldera_add_partitioned_field("phis",1,dims,dimnames,nparts,part_dim)
 
-   ! Last arg is view=false, since AOD fields are *not* views of EAM persistent data.
+   ! Last arg is view=false, since these fields are *not* views of EAM persistent data.
+   call cldera_add_partitioned_field("AEROD_v", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("AODALL", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("ABSORB", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("AODVIS", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("AODABS", 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("aod"    , 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("aod_so2", 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("aod_ash", 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("aod_sulf",1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("FSDS", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("FSDSC", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("FLNT", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("FLUT", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("FLUTC", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("FLNS", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("BURDENSO4", 1,dims,dimnames,nparts,part_dim,.false.)
 
    !2d, mid points
    dims(2) = pver
@@ -367,6 +379,14 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    ! 1d, vertically integrated
    call cldera_add_partitioned_field("te",1,dims,dimnames,nparts,part_dim) ! total energy
    call cldera_add_partitioned_field("tw",1,dims,dimnames,nparts,part_dim) ! total water
+
+   ! cam_in fields
+   call cldera_add_partitioned_field("TREFHT", 1,dims,dimnames,nparts,part_dim)
+   call cldera_add_partitioned_field("TS", 1,dims,dimnames,nparts,part_dim)
+   call cldera_add_partitioned_field("QFLX", 1,dims,dimnames,nparts,part_dim)
+
+   ! cam_out fields
+   call cldera_add_partitioned_field("FLDS", 1,dims,dimnames,nparts,part_dim)
 
    ! Set fields data
    do ipart = 1,nparts
@@ -458,11 +478,39 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
      call cldera_set_field_part_size("tw",ipart,ncols)
      call cldera_set_field_part_data("tw",ipart,field1d)
 
+     ! cam_in fields
+     field1d => cam_in(c)%tref(:)
+     call cldera_set_field_part_size("TREFHT",ipart,ncols)
+     call cldera_set_field_part_data("TREFHT",ipart,field1d)
+     field1d => cam_in(c)%ts(:)
+     call cldera_set_field_part_size("TS",ipart,ncols)
+     call cldera_set_field_part_data("TS",ipart,field1d)
+     field1d => cam_in(c)%cflx(:,1)
+     call cldera_set_field_part_size("QFLX",ipart,ncols)
+     call cldera_set_field_part_data("QFLX",ipart,field1d)
+
+     ! cam_out fields
+     field1d => cam_out(c)%flwds(:)
+     call cldera_set_field_part_size("FLDS",ipart,ncols)
+     call cldera_set_field_part_data("FLDS",ipart,field1d)
+
      ! Copied field (AOD)
+     call cldera_set_field_part_size("AEROD_v", ipart,ncols)
+     call cldera_set_field_part_size("AODALL", ipart,ncols)
+     call cldera_set_field_part_size("ABSORB", ipart,ncols)
+     call cldera_set_field_part_size("AODVIS", ipart,ncols)
+     call cldera_set_field_part_size("AODABS", ipart,ncols)
      call cldera_set_field_part_size("aod"    , ipart,ncols)
      call cldera_set_field_part_size("aod_so2", ipart,ncols)
      call cldera_set_field_part_size("aod_ash", ipart,ncols)
      call cldera_set_field_part_size("aod_sulf",ipart,ncols)
+     call cldera_set_field_part_size("FSDS"   , ipart,ncols)
+     call cldera_set_field_part_size("FSDSC"   , ipart,ncols)
+     call cldera_set_field_part_size("FLNT"   , ipart,ncols)
+     call cldera_set_field_part_size("FLUT"   , ipart,ncols)
+     call cldera_set_field_part_size("FLUTC"   , ipart,ncols)
+     call cldera_set_field_part_size("FLNS"   , ipart,ncols)
+     call cldera_set_field_part_size("BURDENSO4"   , ipart,ncols)
    enddo
 
    call cldera_commit_all_fields()

--- a/components/eam/src/control/cam_comp.F90
+++ b/components/eam/src/control/cam_comp.F90
@@ -140,7 +140,7 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    character(len=cs) :: filein ! Input namelist filename
 #if defined(CLDERA_PROFILING)
    character(len=max_str_len) :: fname
-   integer :: c, nfields, idx, rank, icmp, nparts, part_dim, ipart, fsize, ncols
+   integer :: c, nfields, idx, rank, icmp, nparts, part_dim, ipart, fsize, ncols, icall, tag_loop
    integer :: nlcols,irank
    integer :: dims(3)
    integer, allocatable :: cols_gids(:)
@@ -150,6 +150,8 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    real(r8), pointer :: field1d(:), field2d(:,:), field3d(:,:,:)
    type(physics_buffer_desc), pointer :: field_desc
    character(len=5) :: int_str
+   character(len=4) :: diag(0:2) = (/'    ','_d1 ','_d2 '/)
+   character(len=2) :: tagged_suffix(3) = (/'01', '02', '03'/)
 #endif
    !-----------------------------------------------------------------------
    etamid = nan
@@ -342,24 +344,50 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    call cldera_add_partitioned_field("ABSORB", 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("AODVIS", 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("AODABS", 1,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("AODSO4", 1,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("AODSO401", 1,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("AODSO402", 1,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("AODSO403", 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("aod"    , 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("aod_so2", 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("aod_ash", 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("aod_sulf",1,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("FSDS", 1,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("FSDSC", 1,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("FLNT", 1,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("FLUT", 1,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("FLUTC", 1,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("FLNS", 1,dims,dimnames,nparts,part_dim,.false.)
+   do icall = 2,0,-1 ! profile climate calculation & two diags for now
+      call cldera_add_partitioned_field("SOLIN"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FSDS"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FSNIRTOA"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FSNRTOAC"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FSNRTOAS"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FSNT"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FSNS"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FSNTC"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FSNSC"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FSDSC"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FSNTOA"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FSUTOA"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FSNTOAC"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FSUTOAC"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("SOLS"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("SOLL"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("SOLSD"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("SOLLD"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FSN200"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FSN200C"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("SWCF"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FLNT"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FLUT"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FLUTC"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FLNTC"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FLNS"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FLDSC"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FLNSC"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("LWCF"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FLN200"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FLN200C"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("FLDS"//diag(icall), 1,dims,dimnames,nparts,part_dim,.false.)
+   end do
+   call cldera_add_partitioned_field("AODSO4", 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("BURDENSO4", 1,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("BURDENSO401", 1,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("BURDENSO402", 1,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("BURDENSO403", 1,dims,dimnames,nparts,part_dim,.false.)
+   do tag_loop = 1,3 ! only three tags needed for now
+      call cldera_add_partitioned_field("AODSO4"//tagged_suffix(tag_loop), 1,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("BURDENSO4"//tagged_suffix(tag_loop), 1,dims,dimnames,nparts,part_dim,.false.)
+   end do
 
    ! 2d, mid points
    dims(2) = pver
@@ -377,10 +405,16 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    call cldera_add_partitioned_field("zm",2,dims,dimnames,nparts,part_dim)
 
    ! 2d, mid points (copy)
+   do icall = 2,0,-1 ! profile climate calculation & two diags for now
+      call cldera_add_partitioned_field('QRS'//diag(icall), 2,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field('QRSC'//diag(icall), 2,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("QRL"//diag(icall), 2,dims,dimnames,nparts,part_dim,.false.)
+      call cldera_add_partitioned_field("QRLC"//diag(icall), 2,dims,dimnames,nparts,part_dim,.false.)
+   end do
    call cldera_add_partitioned_field("Mass_so4",2,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("Mass_so401",2,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("Mass_so402",2,dims,dimnames,nparts,part_dim,.false.)
-   call cldera_add_partitioned_field("Mass_so403",2,dims,dimnames,nparts,part_dim,.false.)
+   do tag_loop = 1,3 ! only three tags needed for now
+      call cldera_add_partitioned_field("Mass_so4"//tagged_suffix(tag_loop),2,dims,dimnames,nparts,part_dim,.false.)
+   end do
 
    ! 2d, interfaces
    dims(2) = pver+1
@@ -400,9 +434,6 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    call cldera_add_partitioned_field("QFLX", 1,dims,dimnames,nparts,part_dim)
    call cldera_add_partitioned_field("SHFLX", 1,dims,dimnames,nparts,part_dim)
    call cldera_add_partitioned_field("LHFLX", 1,dims,dimnames,nparts,part_dim)
-
-   ! cam_out fields
-   call cldera_add_partitioned_field("FLDS", 1,dims,dimnames,nparts,part_dim)
 
    ! Set fields data
    do ipart = 1,nparts
@@ -514,39 +545,62 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
      call cldera_set_field_part_size("LHFLX",ipart,ncols)
      call cldera_set_field_part_data("LHFLX",ipart,field1d)
 
-     ! cam_out fields
-     field1d => cam_out(c)%flwds(:)
-     call cldera_set_field_part_size("FLDS",ipart,ncols)
-     call cldera_set_field_part_data("FLDS",ipart,field1d)
-
      ! Copied field
      call cldera_set_field_part_size("AEROD_v", ipart,ncols)
      call cldera_set_field_part_size("AODALL", ipart,ncols)
      call cldera_set_field_part_size("ABSORB", ipart,ncols)
      call cldera_set_field_part_size("AODVIS", ipart,ncols)
      call cldera_set_field_part_size("AODABS", ipart,ncols)
-     call cldera_set_field_part_size("AODSO4", ipart,ncols)
-     call cldera_set_field_part_size("AODSO401", ipart,ncols)
-     call cldera_set_field_part_size("AODSO402", ipart,ncols)
-     call cldera_set_field_part_size("AODSO403", ipart,ncols)
      call cldera_set_field_part_size("aod"    , ipart,ncols)
      call cldera_set_field_part_size("aod_so2", ipart,ncols)
      call cldera_set_field_part_size("aod_ash", ipart,ncols)
      call cldera_set_field_part_size("aod_sulf",ipart,ncols)
-     call cldera_set_field_part_size("FSDS"   , ipart,ncols)
-     call cldera_set_field_part_size("FSDSC"   , ipart,ncols)
-     call cldera_set_field_part_size("FLNT"   , ipart,ncols)
-     call cldera_set_field_part_size("FLUT"   , ipart,ncols)
-     call cldera_set_field_part_size("FLUTC"   , ipart,ncols)
-     call cldera_set_field_part_size("FLNS"   , ipart,ncols)
-     call cldera_set_field_part_size("BURDENSO4"   , ipart,ncols)
-     call cldera_set_field_part_size("BURDENSO401"   , ipart,ncols)
-     call cldera_set_field_part_size("BURDENSO402"   , ipart,ncols)
-     call cldera_set_field_part_size("BURDENSO403"   , ipart,ncols)
+     do icall = 2,0,-1 ! profile climate calculation & two diags for now
+       call cldera_set_field_part_size("SOLIN"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FSDS"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FSNIRTOA"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FSNRTOAC"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FSNRTOAS"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FSNT"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FSNS"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FSNTC"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FSNSC"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FSDSC"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FSNTOA"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FSUTOA"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FSNTOAC"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FSUTOAC"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("SOLS"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("SOLL"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("SOLSD"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("SOLLD"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FSN200"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FSN200C"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("SWCF"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FLNT"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FLUT"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FLUTC"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FLNTC"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FLNS"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FLDSC"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FLNSC"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("LWCF"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FLN200"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FLN200C"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("FLDS"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("QRS"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("QRSC"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("QRL"//diag(icall), ipart,ncols)
+       call cldera_set_field_part_size("QRLC"//diag(icall), ipart,ncols)
+     end do
+     call cldera_set_field_part_size("AODSO4", ipart,ncols)
+     call cldera_set_field_part_size("BURDENSO4", ipart,ncols)
      call cldera_set_field_part_size("Mass_so4", ipart,ncols)
-     call cldera_set_field_part_size("Mass_so401", ipart,ncols)
-     call cldera_set_field_part_size("Mass_so402", ipart,ncols)
-     call cldera_set_field_part_size("Mass_so403", ipart,ncols)
+     do tag_loop = 1,3 ! only three tags needed for now
+       call cldera_set_field_part_size("AODSO4"//tagged_suffix(tag_loop), ipart,ncols)
+       call cldera_set_field_part_size("BURDENSO4"//tagged_suffix(tag_loop), ipart,ncols)
+       call cldera_set_field_part_size("Mass_so4"//tagged_suffix(tag_loop), ipart,ncols)
+     end do
    enddo
 
    call cldera_commit_all_fields()

--- a/components/eam/src/control/cam_comp.F90
+++ b/components/eam/src/control/cam_comp.F90
@@ -342,6 +342,10 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    call cldera_add_partitioned_field("ABSORB", 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("AODVIS", 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("AODABS", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("AODSO4", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("AODSO401", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("AODSO402", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("AODSO403", 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("aod"    , 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("aod_so2", 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("aod_ash", 1,dims,dimnames,nparts,part_dim,.false.)
@@ -353,8 +357,11 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    call cldera_add_partitioned_field("FLUTC", 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("FLNS", 1,dims,dimnames,nparts,part_dim,.false.)
    call cldera_add_partitioned_field("BURDENSO4", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("BURDENSO401", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("BURDENSO402", 1,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("BURDENSO403", 1,dims,dimnames,nparts,part_dim,.false.)
 
-   !2d, mid points
+   ! 2d, mid points
    dims(2) = pver
    dimnames(2) = 'lev'
    call cldera_add_partitioned_field("T",2,dims,dimnames,nparts,part_dim)
@@ -369,6 +376,12 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    call cldera_add_partitioned_field("exner",2,dims,dimnames,nparts,part_dim)
    call cldera_add_partitioned_field("zm",2,dims,dimnames,nparts,part_dim)
 
+   ! 2d, mid points (copy)
+   call cldera_add_partitioned_field("Mass_so4",2,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("Mass_so401",2,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("Mass_so402",2,dims,dimnames,nparts,part_dim,.false.)
+   call cldera_add_partitioned_field("Mass_so403",2,dims,dimnames,nparts,part_dim,.false.)
+
    ! 2d, interfaces
    dims(2) = pver+1
    dimnames(2) = "ilev"
@@ -382,8 +395,11 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
 
    ! cam_in fields
    call cldera_add_partitioned_field("TREFHT", 1,dims,dimnames,nparts,part_dim)
+   call cldera_add_partitioned_field("QREFHT", 1,dims,dimnames,nparts,part_dim)
    call cldera_add_partitioned_field("TS", 1,dims,dimnames,nparts,part_dim)
    call cldera_add_partitioned_field("QFLX", 1,dims,dimnames,nparts,part_dim)
+   call cldera_add_partitioned_field("SHFLX", 1,dims,dimnames,nparts,part_dim)
+   call cldera_add_partitioned_field("LHFLX", 1,dims,dimnames,nparts,part_dim)
 
    ! cam_out fields
    call cldera_add_partitioned_field("FLDS", 1,dims,dimnames,nparts,part_dim)
@@ -482,24 +498,37 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
      field1d => cam_in(c)%tref(:)
      call cldera_set_field_part_size("TREFHT",ipart,ncols)
      call cldera_set_field_part_data("TREFHT",ipart,field1d)
+     field1d => cam_in(c)%qref(:)
+     call cldera_set_field_part_size("QREFHT",ipart,ncols)
+     call cldera_set_field_part_data("QREFHT",ipart,field1d)
      field1d => cam_in(c)%ts(:)
      call cldera_set_field_part_size("TS",ipart,ncols)
      call cldera_set_field_part_data("TS",ipart,field1d)
      field1d => cam_in(c)%cflx(:,1)
      call cldera_set_field_part_size("QFLX",ipart,ncols)
      call cldera_set_field_part_data("QFLX",ipart,field1d)
+     field1d => cam_in(c)%shf(:)
+     call cldera_set_field_part_size("SHFLX",ipart,ncols)
+     call cldera_set_field_part_data("SHFLX",ipart,field1d)
+     field1d => cam_in(c)%lhf(:)
+     call cldera_set_field_part_size("LHFLX",ipart,ncols)
+     call cldera_set_field_part_data("LHFLX",ipart,field1d)
 
      ! cam_out fields
      field1d => cam_out(c)%flwds(:)
      call cldera_set_field_part_size("FLDS",ipart,ncols)
      call cldera_set_field_part_data("FLDS",ipart,field1d)
 
-     ! Copied field (AOD)
+     ! Copied field
      call cldera_set_field_part_size("AEROD_v", ipart,ncols)
      call cldera_set_field_part_size("AODALL", ipart,ncols)
      call cldera_set_field_part_size("ABSORB", ipart,ncols)
      call cldera_set_field_part_size("AODVIS", ipart,ncols)
      call cldera_set_field_part_size("AODABS", ipart,ncols)
+     call cldera_set_field_part_size("AODSO4", ipart,ncols)
+     call cldera_set_field_part_size("AODSO401", ipart,ncols)
+     call cldera_set_field_part_size("AODSO402", ipart,ncols)
+     call cldera_set_field_part_size("AODSO403", ipart,ncols)
      call cldera_set_field_part_size("aod"    , ipart,ncols)
      call cldera_set_field_part_size("aod_so2", ipart,ncols)
      call cldera_set_field_part_size("aod_ash", ipart,ncols)
@@ -511,6 +540,13 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
      call cldera_set_field_part_size("FLUTC"   , ipart,ncols)
      call cldera_set_field_part_size("FLNS"   , ipart,ncols)
      call cldera_set_field_part_size("BURDENSO4"   , ipart,ncols)
+     call cldera_set_field_part_size("BURDENSO401"   , ipart,ncols)
+     call cldera_set_field_part_size("BURDENSO402"   , ipart,ncols)
+     call cldera_set_field_part_size("BURDENSO403"   , ipart,ncols)
+     call cldera_set_field_part_size("Mass_so4", ipart,ncols)
+     call cldera_set_field_part_size("Mass_so401", ipart,ncols)
+     call cldera_set_field_part_size("Mass_so402", ipart,ncols)
+     call cldera_set_field_part_size("Mass_so403", ipart,ncols)
    enddo
 
    call cldera_commit_all_fields()

--- a/components/eam/src/physics/cam/aer_rad_props.F90
+++ b/components/eam/src/physics/cam/aer_rad_props.F90
@@ -25,6 +25,10 @@ use ref_pres,     only: clim_modal_aero_top_lev
 use cam_abortutils,       only: endrun
 use tropopause,           only : tropopause_find
 use cam_logfile,          only: iulog
+#if defined(CLDERA_PROFILING)
+use ppgrid,         only: begchunk
+use cldera_interface_mod, only: cldera_set_field_part_data
+#endif
 
 implicit none
 private
@@ -894,6 +898,13 @@ subroutine aer_vis_diag_out(lchnk, ncol, nnite, idxnite, iaer, tau, diag_idx)
    else
       call outfld('AEROD_v', tmp, pcols, lchnk)
    end if
+
+#if defined(CLDERA_PROFILING)
+   if (iaer <= 0) then
+     call cldera_set_field_part_data("AEROD_v" ,lchnk-begchunk+1,tmp)
+   end if
+#endif
+
 
 end subroutine aer_vis_diag_out
 

--- a/components/eam/src/physics/cam/modal_aer_opt.F90
+++ b/components/eam/src/physics/cam/modal_aer_opt.F90
@@ -1466,9 +1466,9 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
       call cldera_set_field_part_data("AODSO4" ,lchnk-begchunk+1,so4aod)
       call cldera_set_field_part_data("BURDENSO4" ,lchnk-begchunk+1,burdenso4)
 
-      ! Only three tags needed for now
-      if (nso4>2) then
-         do tag_loop = 1,3
+      if (nso4>1) then
+         do tag_loop = 1,nso4
+            if (tag_loop>3) exit ! Only three tags needed for now
             call cldera_set_field_part_data("AODSO4"//tagged_sulfur_suffix(tag_loop),lchnk-begchunk+1,so4aod_tag(:,tag_loop))
             call cldera_set_field_part_data("BURDENSO4"//tagged_sulfur_suffix(tag_loop),lchnk-begchunk+1,burdenso4_tag(:,tag_loop))
          end do

--- a/components/eam/src/physics/cam/modal_aer_opt.F90
+++ b/components/eam/src/physics/cam/modal_aer_opt.F90
@@ -36,6 +36,10 @@ use modal_aero_wateruptake, only: modal_aero_wateruptake_dr
 use modal_aero_calcsize,    only: modal_aero_calcsize_diag,modal_aero_calcsize_sub
 use shr_log_mod ,           only: errmsg => shr_log_errmsg
 use modal_aero_data,only: nso4, nbc, npoa, nsoa
+#if defined(CLDERA_PROFILING)
+use ppgrid,         only: begchunk
+use cldera_interface_mod, only: cldera_set_field_part_data
+#endif
 
 implicit none
 private
@@ -1453,6 +1457,15 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
       call outfld('AODPROT',         protaod,    pcols, lchnk)
       call outfld('AODLIP',         lipaod,    pcols, lchnk)
 #endif
+
+#if defined(CLDERA_PROFILING)
+      call cldera_set_field_part_data("ABSORB" ,lchnk-begchunk+1,absorb)
+      call cldera_set_field_part_data("AODVIS" ,lchnk-begchunk+1,aodvis)
+      call cldera_set_field_part_data("AODALL" ,lchnk-begchunk+1,aodall)
+      call cldera_set_field_part_data("AODABS" ,lchnk-begchunk+1,aodabs)
+      call cldera_set_field_part_data("BURDENSO4" ,lchnk-begchunk+1,burdenso4)
+#endif
+
    end if
 
 end subroutine modal_aero_sw

--- a/components/eam/src/physics/cam/modal_aer_opt.F90
+++ b/components/eam/src/physics/cam/modal_aer_opt.F90
@@ -1463,7 +1463,16 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
       call cldera_set_field_part_data("AODVIS" ,lchnk-begchunk+1,aodvis)
       call cldera_set_field_part_data("AODALL" ,lchnk-begchunk+1,aodall)
       call cldera_set_field_part_data("AODABS" ,lchnk-begchunk+1,aodabs)
+      call cldera_set_field_part_data("AODSO4" ,lchnk-begchunk+1,so4aod)
       call cldera_set_field_part_data("BURDENSO4" ,lchnk-begchunk+1,burdenso4)
+
+      ! Only three tags needed for now
+      if (nso4>2) then
+         do tag_loop = 1,3
+            call cldera_set_field_part_data("AODSO4"//tagged_sulfur_suffix(tag_loop),lchnk-begchunk+1,so4aod_tag(:,tag_loop))
+            call cldera_set_field_part_data("BURDENSO4"//tagged_sulfur_suffix(tag_loop),lchnk-begchunk+1,burdenso4_tag(:,tag_loop))
+         end do
+      end if
 #endif
 
    end if

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -993,6 +993,9 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
 #if ( defined OFFLINE_DYN )
      use metdata,       only: get_met_srf1
 #endif
+#if defined(CLDERA_PROFILING)
+    use cam_control_mod,    only: nsrest  ! restart flag
+#endif
 
     !
     ! Input arguments
@@ -1025,6 +1028,9 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
     integer(i8) :: sysclock_max                  ! system clock max value
     real(r8)    :: chunk_cost                    ! measured cost per chunk
     type(physics_buffer_desc), pointer :: phys_buffer_chunk(:)
+#if defined(CLDERA_PROFILING)
+    integer :: ymd, yr, mon, day, tod            ! components of a date
+#endif
 
     call t_startf ('physpkg_st1')
     nstep = get_nstep()
@@ -1120,6 +1126,28 @@ subroutine phys_run1(phys_state, ztodt, phys_tend, pbuf2d,  cam_in, cam_out)
 
        !call t_adj_detailf(-1)
        call t_stopf ('bc_physics')
+
+#if defined(CLDERA_PROFILING)
+      ! Note: we need to compute stats *after* EAM has completed the physics calculations above
+      ! The tphysbc call will update tendencies (for the BC physics), and call outfld for all
+      ! diags/state vars. So computing stats here should get *the same* values that we get from
+      ! regular EAM output.
+      if (.not. is_atm_init) then
+        if (first_time_step .and. nsrest .eq. 0) then
+          if (masterproc) then
+            print *, "WARNING! You are using a workaround to issue E3SM-Project/e3sm#5904"
+            print *, "         If that issue has been resolved, remove this hack"
+          endif
+          first_time_step = .false.
+        else
+          call get_prev_date( yr, mon, day, tod)
+          ymd = yr*10000 + mon*100 + day
+          call t_startf('cldera_compute_stats')
+          call cldera_compute_stats(ymd,tod)
+          call t_stopf('cldera_compute_stats')
+        endif
+      endif
+#endif
 
        ! Don't call the rest in CRM mode
        if(single_column.and.scm_crm_mode) return
@@ -1573,7 +1601,6 @@ subroutine tphysac (ztodt,   cam_in,  &
     integer :: lchnk                                ! chunk identifier
     integer :: ncol                                 ! number of atmospheric columns
     integer i,k,m                 ! Longitude, level indices
-    integer :: yr, mon, day, tod       ! components of a date
     integer :: ixcldice, ixcldliq      ! constituent indices for cloud liquid and ice water.
 
     logical :: labort                            ! abort flag
@@ -2036,7 +2063,6 @@ subroutine tphysbc (ztodt,               &
     use phys_control,    only: use_qqflx_fixer, use_mass_borrower
     use nudging,         only: Nudge_Model,Nudge_Loc_PhysOut,nudging_calc_tend
     use lnd_infodata,    only: precip_downscaling_method
-    use cam_control_mod,    only: nsrest  ! restart flag
 
     implicit none
 
@@ -2777,26 +2803,6 @@ end if
     ! Moist physical parameteriztions complete: 
     ! send dynamical variables, and derived variables to history file
     !===================================================
-#if defined(CLDERA_PROFILING)
-   ! Compute stats here, so that we get the same values for phys state var as
-   ! we would get in the EAM history file, right below
-   if (.not. is_atm_init) then
-     if (first_time_step .and. nsrest .eq. 0) then
-       if (masterproc) then
-         print *, "WARNING! You are using a workaround to issue E3SM-Project/e3sm#5904"
-         print *, "         If that issue has been resolved, remove this hack"
-       endif
-       first_time_step = .false.
-     else
-       call get_prev_date( yr, mon, day, tod)
-       ymd = yr*10000 + mon*100 + day
-       call t_startf('cldera_compute_stats')
-       call cldera_compute_stats(ymd,tod)
-       call t_stopf('cldera_compute_stats')
-     endif
-   endif
-#endif
-
 
     call t_startf('bc_history_write')
     call diag_phys_writeout(state, cam_out%psl)

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -888,6 +888,10 @@ end function radiation_nextsw_cday
     use rrtmg_state, only: rrtmg_state_create, rrtmg_state_update, rrtmg_state_destroy, rrtmg_state_t, num_rrtmg_levs
     use orbit,            only: zenith
     use output_aerocom_aie , only: do_aerocom_ind3
+#if defined(CLDERA_PROFILING)
+    use ppgrid,         only: begchunk
+    use cldera_interface_mod, only: cldera_set_field_part_data
+#endif
 
     ! Arguments
     logical,  intent(in)    :: is_cmip6_volc    ! true if cmip6 style volcanic file is read otherwise false 
@@ -1403,6 +1407,13 @@ end function radiation_nextsw_cday
                   call outfld('FSN200C'//diag(icall),fsn200c,pcols,lchnk)
                   call outfld('SWCF'//diag(icall),swcf  ,pcols,lchnk)
 
+#if defined(CLDERA_PROFILING)
+                  if (icall == 0) then ! profile climate calculation
+                     call cldera_set_field_part_data('FSDS',lchnk-begchunk+1,fsds)
+                     call cldera_set_field_part_data('FSDSC',lchnk-begchunk+1,fsdsc)
+                  endif
+#endif
+
               end if ! (active_calls(icall))
           end do ! icall
           call t_stopf ('rad_sw_loop')
@@ -1500,6 +1511,15 @@ end function radiation_nextsw_cday
                   call outfld('FLN200'//diag(icall),fln200,pcols,lchnk)
                   call outfld('FLN200C'//diag(icall),fln200c,pcols,lchnk)
                   call outfld('FLDS'//diag(icall),cam_out%flwds ,pcols,lchnk)
+
+#if defined(CLDERA_PROFILING)
+                  if (icall == 0) then ! profile climate calculation
+                     call cldera_set_field_part_data('FLNT',lchnk-begchunk+1,flnt)
+                     call cldera_set_field_part_data('FLUT',lchnk-begchunk+1,flut)
+                     call cldera_set_field_part_data('FLUTC',lchnk-begchunk+1,flutc)
+                     call cldera_set_field_part_data('FLNS',lchnk-begchunk+1,flns)
+                  endif
+#endif
 
               end if
           end do

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -1408,9 +1408,30 @@ end function radiation_nextsw_cday
                   call outfld('SWCF'//diag(icall),swcf  ,pcols,lchnk)
 
 #if defined(CLDERA_PROFILING)
-                  if (icall == 0) then ! profile climate calculation
-                     call cldera_set_field_part_data('FSDS',lchnk-begchunk+1,fsds)
-                     call cldera_set_field_part_data('FSDSC',lchnk-begchunk+1,fsdsc)
+                  if (icall < 3) then ! profile climate calculation & two diags for now
+                     call cldera_set_field_part_data('QRS'//diag(icall),lchnk-begchunk+1,qrs(:ncol,:pver)/cpair)
+                     call cldera_set_field_part_data('QRSC'//diag(icall),lchnk-begchunk+1,qrsc(:ncol,:pver)/cpair)
+                     call cldera_set_field_part_data('SOLIN'//diag(icall),lchnk-begchunk+1,solin)
+                     call cldera_set_field_part_data('FSDS'//diag(icall),lchnk-begchunk+1,fsds)
+                     call cldera_set_field_part_data('FSNIRTOA'//diag(icall),lchnk-begchunk+1,fsnirt)
+                     call cldera_set_field_part_data('FSNRTOAC'//diag(icall),lchnk-begchunk+1,fsnrtc)
+                     call cldera_set_field_part_data('FSNRTOAS'//diag(icall),lchnk-begchunk+1,fsnirtsq)
+                     call cldera_set_field_part_data('FSNT'//diag(icall),lchnk-begchunk+1,fsnt)
+                     call cldera_set_field_part_data('FSNS'//diag(icall),lchnk-begchunk+1,fsns)
+                     call cldera_set_field_part_data('FSNTC'//diag(icall),lchnk-begchunk+1,fsntc)
+                     call cldera_set_field_part_data('FSNSC'//diag(icall),lchnk-begchunk+1,fsnsc)
+                     call cldera_set_field_part_data('FSDSC'//diag(icall),lchnk-begchunk+1,fsdsc)
+                     call cldera_set_field_part_data('FSNTOA'//diag(icall),lchnk-begchunk+1,fsntoa)
+                     call cldera_set_field_part_data('FSUTOA'//diag(icall),lchnk-begchunk+1,fsutoa)
+                     call cldera_set_field_part_data('FSNTOAC'//diag(icall),lchnk-begchunk+1,fsntoac)
+                     call cldera_set_field_part_data('FSUTOAC'//diag(icall),lchnk-begchunk+1,fsutoac)
+                     call cldera_set_field_part_data('SOLS'//diag(icall),lchnk-begchunk+1,cam_out%sols)
+                     call cldera_set_field_part_data('SOLL'//diag(icall),lchnk-begchunk+1,cam_out%soll)
+                     call cldera_set_field_part_data('SOLSD'//diag(icall),lchnk-begchunk+1,cam_out%solsd)
+                     call cldera_set_field_part_data('SOLLD'//diag(icall),lchnk-begchunk+1,cam_out%solld)
+                     call cldera_set_field_part_data('FSN200'//diag(icall),lchnk-begchunk+1,fsn200)
+                     call cldera_set_field_part_data('FSN200C'//diag(icall),lchnk-begchunk+1,fsn200c)
+                     call cldera_set_field_part_data('SWCF'//diag(icall),lchnk-begchunk+1,swcf)
                   endif
 #endif
 
@@ -1513,11 +1534,21 @@ end function radiation_nextsw_cday
                   call outfld('FLDS'//diag(icall),cam_out%flwds ,pcols,lchnk)
 
 #if defined(CLDERA_PROFILING)
-                  if (icall == 0) then ! profile climate calculation
-                     call cldera_set_field_part_data('FLNT',lchnk-begchunk+1,flnt)
-                     call cldera_set_field_part_data('FLUT',lchnk-begchunk+1,flut)
-                     call cldera_set_field_part_data('FLUTC',lchnk-begchunk+1,flutc)
-                     call cldera_set_field_part_data('FLNS',lchnk-begchunk+1,flns)
+                  if (icall < 3) then ! profile climate calculation & two diags for now
+                     call cldera_set_field_part_data('QRL'//diag(icall),lchnk-begchunk+1,qrl(:ncol,:)/cpair)
+                     call cldera_set_field_part_data('QRLC'//diag(icall),lchnk-begchunk+1,qrlc(:ncol,:)/cpair)
+                     call cldera_set_field_part_data('FLNT'//diag(icall),lchnk-begchunk+1,flnt)
+                     call cldera_set_field_part_data('FLUT'//diag(icall),lchnk-begchunk+1,flut)
+                     call cldera_set_field_part_data('FLUTC'//diag(icall),lchnk-begchunk+1,flutc)
+                     call cldera_set_field_part_data('FLNTC'//diag(icall),lchnk-begchunk+1,flntc)
+                     call cldera_set_field_part_data('FLNS'//diag(icall),lchnk-begchunk+1,flns)
+
+                     call cldera_set_field_part_data('FLDSC'//diag(icall),lchnk-begchunk+1,fldsc)
+                     call cldera_set_field_part_data('FLNSC'//diag(icall),lchnk-begchunk+1,flnsc)
+                     call cldera_set_field_part_data('LWCF'//diag(icall),lchnk-begchunk+1,lwcf)
+                     call cldera_set_field_part_data('FLN200'//diag(icall),lchnk-begchunk+1,fln200)
+                     call cldera_set_field_part_data('FLN200C'//diag(icall),lchnk-begchunk+1,fln200c)
+                     call cldera_set_field_part_data('FLDS'//diag(icall),lchnk-begchunk+1,cam_out%flwds)
                   endif
 #endif
 


### PR DESCRIPTION
This adds the extra cldera-tools hooks needed for tagging.

This also includes the master merge from https://github.com/sandialabs/CLDERA-E3SM/pull/58.

I verified this runs fine with a modified version of Benj's 7Tg tagged tracer case and collects values (although we still need to verify if the values make sense).