### PR TITLE
Modify cldera-tools path for pmcpu

### DIFF
--- a/cime_config/machines/cmake_macros/gnu_pm-cpu.cmake
+++ b/cime_config/machines/cmake_macros/gnu_pm-cpu.cmake
@@ -1,4 +1,4 @@
-set(CLDERA_PATH "/global/cfs/cdirs/m4014/cldera-tools/install/pmcpu")
+set(CLDERA_PATH "/global/cfs/cdirs/m4014/cldera-tools/install-master/pmcpu")
 string(APPEND CONFIG_ARGS " --host=cray")
 if (COMP_NAME STREQUAL gptl)
   string(APPEND CPPDEFS " -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY")

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -146,7 +146,7 @@
     <TEST_TPUT_TOLERANCE>0.1</TEST_TPUT_TOLERANCE>
 
     <environment_variables>
-      <env name="CLDERA_PATH">/global/cfs/cdirs/m4014/cldera-tools/install/pmcpu</env>
+      <env name="CLDERA_PATH">/global/cfs/cdirs/m4014/cldera-tools/install-master/pmcpu</env>
       <env name="MPICH_ENV_DISPLAY">1</env>
       <env name="MPICH_VERSION_DISPLAY">1</env>
       <env name="OMP_STACKSIZE">128M</env>


### PR DESCRIPTION
We still need to run sims with old cldera-tools with hunter's branch on pmcpu. This modifies the path to cldera-tools for cldera-e3sm/master so we can start running sims with the latest cldera-tools without breaking old sims.