### PR TITLE
Modify cldera-tools path for boca

### DIFF
--- a/cime_config/machines/cmake_macros/intel_boca.cmake
+++ b/cime_config/machines/cmake_macros/intel_boca.cmake
@@ -1,5 +1,5 @@
 set(ALBANY_PATH "/projects/ccsm/AlbanyTrilinos_20190904/albany-build/install")
-set(CLDERA_PATH "/projects/cldera/cldera-tools/install/intel/")
+set(CLDERA_PATH "/projects/cldera/cldera-tools/install-master/intel/")
 if (COMP_NAME STREQUAL gptl)
   string(APPEND CPPDEFS " -DHAVE_SLASHPROC")
 endif()

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1197,7 +1197,7 @@
       <env name="PNETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
     </environment_variables>
     <environment_variables compiler="intel">
-      <env name="CLDERA_PATH">/projects/cldera/cldera-tools/install/intel</env>
+      <env name="CLDERA_PATH">/projects/cldera/cldera-tools/install-master/intel</env>
     </environment_variables>
   </machine>
 


### PR DESCRIPTION
We still need to run sims with old cldera-tools with hunter's branch on boca. This modifies the path to cldera-tools for cldera-e3sm/master so we can start running sims with the latest cldera-tools without breaking old sims.