### PR TITLE
Add d3 variables to cldera-tools output

### DIFF
--- a/components/eam/src/control/cam_comp.F90
+++ b/components/eam/src/control/cam_comp.F90
@@ -150,7 +150,7 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    real(r8), pointer :: field1d(:), field2d(:,:), field3d(:,:,:)
    type(physics_buffer_desc), pointer :: field_desc
    character(len=5) :: int_str
-   character(len=4) :: diag(0:2) = (/'    ','_d1 ','_d2 '/)
+   character(len=4) :: diag(0:3) = (/'    ','_d1 ','_d2 ','_d3 '/)
    character(len=2) :: tagged_suffix(3) = (/'01', '02', '03'/)
 #endif
    !-----------------------------------------------------------------------
@@ -349,7 +349,7 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    call cldera_add_partitioned_field("aod_so2", 1,dims,dimnames,nparts,part_dim,part_alloc_size,.false.)
    call cldera_add_partitioned_field("aod_ash", 1,dims,dimnames,nparts,part_dim,part_alloc_size,.false.)
    call cldera_add_partitioned_field("aod_sulf",1,dims,dimnames,nparts,part_dim,part_alloc_size,.false.)
-   do icall = 2,0,-1 ! profile climate calculation & two diags for now
+   do icall = 3,0,-1 ! profile climate calculation & three diags for now
       call cldera_add_partitioned_field("SOLIN"//diag(icall), 1,dims,dimnames,nparts,part_dim,part_alloc_size,.false.)
       call cldera_add_partitioned_field("FSDS"//diag(icall), 1,dims,dimnames,nparts,part_dim,part_alloc_size,.false.)
       call cldera_add_partitioned_field("FSNIRTOA"//diag(icall), 1,dims,dimnames,nparts,part_dim,part_alloc_size,.false.)
@@ -406,7 +406,7 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
    call cldera_add_partitioned_field("zm",2,dims,dimnames,nparts,part_dim,part_alloc_size)
 
    ! 2d, mid points (copy)
-   do icall = 2,0,-1 ! profile climate calculation & two diags for now
+   do icall = 3,0,-1 ! profile climate calculation & three diags for now
       call cldera_add_partitioned_field('QRS'//diag(icall), 2,dims,dimnames,nparts,part_dim,part_alloc_size,.false.)
       call cldera_add_partitioned_field('QRSC'//diag(icall), 2,dims,dimnames,nparts,part_dim,part_alloc_size,.false.)
       call cldera_add_partitioned_field("QRL"//diag(icall), 2,dims,dimnames,nparts,part_dim,part_alloc_size,.false.)
@@ -556,7 +556,7 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
      call cldera_set_field_part_extent("aod_so2", ipart,ncols)
      call cldera_set_field_part_extent("aod_ash", ipart,ncols)
      call cldera_set_field_part_extent("aod_sulf",ipart,ncols)
-     do icall = 2,0,-1 ! profile climate calculation & two diags for now
+     do icall = 3,0,-1 ! profile climate calculation & three diags for now
        call cldera_set_field_part_extent("SOLIN"//diag(icall), ipart,ncols)
        call cldera_set_field_part_extent("FSDS"//diag(icall), ipart,ncols)
        call cldera_set_field_part_extent("FSNIRTOA"//diag(icall), ipart,ncols)

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -1408,7 +1408,7 @@ end function radiation_nextsw_cday
                   call outfld('SWCF'//diag(icall),swcf  ,pcols,lchnk)
 
 #if defined(CLDERA_PROFILING)
-                  if (icall < 3) then ! profile climate calculation & two diags for now
+                  if (icall < 4) then ! profile climate calculation & three diags for now
                      call cldera_set_field_part_data('QRS'//diag(icall),lchnk-begchunk+1,qrs(:ncol,:pver)/cpair)
                      call cldera_set_field_part_data('QRSC'//diag(icall),lchnk-begchunk+1,qrsc(:ncol,:pver)/cpair)
                      call cldera_set_field_part_data('SOLIN'//diag(icall),lchnk-begchunk+1,solin)
@@ -1534,7 +1534,7 @@ end function radiation_nextsw_cday
                   call outfld('FLDS'//diag(icall),cam_out%flwds ,pcols,lchnk)
 
 #if defined(CLDERA_PROFILING)
-                  if (icall < 3) then ! profile climate calculation & two diags for now
+                  if (icall < 4) then ! profile climate calculation & three diags for now
                      call cldera_set_field_part_data('QRL'//diag(icall),lchnk-begchunk+1,qrl(:ncol,:)/cpair)
                      call cldera_set_field_part_data('QRLC'//diag(icall),lchnk-begchunk+1,qrlc(:ncol,:)/cpair)
                      call cldera_set_field_part_data('FLNT'//diag(icall),lchnk-begchunk+1,flnt)


### PR DESCRIPTION
This is needed for cldera-tools to output radiative diagnostics without Cerro Hudson - i.e. "_d3".

not tested - will try a run on boca