### PR TITLE
Add hooks for ELM

### DIFF
--- a/cime_config/machines/cmake_macros/gnu_mappy.cmake
+++ b/cime_config/machines/cmake_macros/gnu_mappy.cmake
@@ -1,5 +1,6 @@
 set(ALBANY_PATH "/projects/install/rhel7-x86_64/ACME/AlbanyTrilinos/Albany/build/install")
-set(CLDERA_PATH "/sems-data-store/ACME/cldera/cldera-tools/install")
+#set(CLDERA_PATH "/sems-data-store/ACME/cldera/cldera-tools/install")
+set(CLDERA_PATH "/ascldap/users/gbharpe/Programming/cldera-tools-build")
 if (COMP_NAME STREQUAL gptl)
   string(APPEND CPPDEFS " -DHAVE_SLASHPROC")
 endif()

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -804,7 +804,8 @@
     <MAX_GB_OLD_TEST_DATA>0</MAX_GB_OLD_TEST_DATA>
     <!--    <GMAKE>make</GMAKE> <- this doesn't actually work! -->
     <environment_variables>
-      <env name="CLDERA_PATH">/sems-data-store/ACME/cldera/cldera-tools/install</env>
+      <!-- <env name="CLDERA_PATH">/sems-data-store/ACME/cldera/cldera-tools/install</env> -->
+      <env name="CLDERA_PATH">/ascldap/users/gbharpe/Programming/cldera-tools-build</env>
       <env name="NETCDFROOT">$ENV{SEMS_NETCDF_ROOT}</env>
       <env name="OMP_STACKSIZE">64M</env>
       <env name="OMP_PROC_BIND">spread</env>

--- a/components/eam/src/control/cam_comp.F90
+++ b/components/eam/src/control/cam_comp.F90
@@ -103,7 +103,7 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
                                    cldera_set_field_part_extent, &
                                    cldera_set_field_part_data, &
                                    cldera_commit_all_fields,   &
-                                   cldera_commit_field
+                                   cldera_commit_field, cldera_switch_context
    use physics_buffer,   only: physics_buffer_desc, col_type_grid, pbuf_get_index, &
                                pbuf_get_field_rank, pbuf_get_field_dims, pbuf_get_field, &
                                pbuf_get_field_name, pbuf_has_field, pbuf_get_field_persistence, &
@@ -230,6 +230,7 @@ subroutine cam_init( cam_out, cam_in, mpicom_atm, &
 
 #if defined(CLDERA_PROFILING)
    call t_startf('cldera_add_fields')
+   call cldera_switch_context("eam")
    nparts = endchunk - begchunk + 1
 
    ! All fields are partitioned over cols index, which is the first

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -890,7 +890,7 @@ end function radiation_nextsw_cday
     use output_aerocom_aie , only: do_aerocom_ind3
 #if defined(CLDERA_PROFILING)
     use ppgrid,         only: begchunk
-    use cldera_interface_mod, only: cldera_set_field_part_data
+    use cldera_interface_mod, only: cldera_set_field_part_data, cldera_switch_context
 #endif
 
     ! Arguments
@@ -1408,6 +1408,7 @@ end function radiation_nextsw_cday
                   call outfld('SWCF'//diag(icall),swcf  ,pcols,lchnk)
 
 #if defined(CLDERA_PROFILING)
+                  call cldera_switch_context("eam")
                   if (icall < 3) then ! profile climate calculation & two diags for now
                      call cldera_set_field_part_data('QRS'//diag(icall),lchnk-begchunk+1,qrs(:ncol,:pver)/cpair)
                      call cldera_set_field_part_data('QRSC'//diag(icall),lchnk-begchunk+1,qrsc(:ncol,:pver)/cpair)

--- a/components/elm/src/biogeophys/SurfaceRadiationMod.F90
+++ b/components/elm/src/biogeophys/SurfaceRadiationMod.F90
@@ -95,6 +95,16 @@ contains
   subroutine InitAllocate(this, bounds)
     !
     ! !USES:
+#if defined(CLDERA_PROFILING)
+    use iso_c_binding, only: c_loc
+!    use cldera_interface_mod, only: cldera_init, cldera_set_log_unit, &
+!                                    cldera_set_masterproc, max_str_len, &
+!                                    cldera_add_partitioned_field, &
+!                                    cldera_set_field_part_extent, &
+!                                    cldera_set_field_part_data, &
+!                                    cldera_commit_all_fields,   &
+!                                    cldera_commit_field
+#endif
     !use shr_infnan_mod, only : nan => shr_infnan_nan, assignment(=)
     !
     ! !ARGUMENTS:

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -33,6 +33,9 @@ contains
   !====================================================================================
 
   subroutine lnd_init_mct( EClock, cdata_l, x2l_l, l2x_l, NLFilename )
+#if defined(CLDERA_PROFILING)
+    use cldera_interface_mod, only: cldera_init, cldera_set_log_unit, cldera_set_masterproc
+#endif
     !
     ! !DESCRIPTION:
     ! Initialize land surface model and obtain relevant atmospheric model arrays
@@ -230,6 +233,15 @@ contains
     else
        call endrun( sub//' ERROR: unknown starttype' )
     end if
+
+#if false && defined(CLDERA_PROFILING)
+    ! Initialize CLDERA profiling before elm_init, but after time init
+    call t_startf('cldera_init')
+    call cldera_init(mpicom_lnd,start_ymd,start_tod,curr_ymd,curr_tod,stop_ymd,stop_tod)
+    call cldera_set_log_unit (iulog)
+    call cldera_set_masterproc (masterproc)
+    call t_stopf('cldera_init')
+#endif
 
     call elm_varctl_set(caseid_in=caseid, ctitle_in=ctitle,                     &
                         brnch_retain_casename_in=brnch_retain_casename,         &

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -566,6 +566,10 @@ contains
   !====================================================================================
 
   subroutine lnd_final_mct( EClock, cdata_l, x2l_l, l2x_l)
+#if defined(CLDERA_PROFILING)
+    use cldera_interface_mod, only: cldera_clean_up
+#endif
+
     !
     ! !DESCRIPTION:
     ! Finalize land surface model
@@ -587,6 +591,11 @@ contains
     ! fill this in
     call final()
 
+#if false && defined(CLDERA_PROFILING)
+    call t_startf('cldera_clean_up')
+    call cldera_clean_up ()
+    call t_stopf('cldera_clean_up')
+#endif
   end subroutine lnd_final_mct
 
   !====================================================================================

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -237,7 +237,8 @@ contains
 #if defined(CLDERA_PROFILING)
     ! Initialize CLDERA profiling before elm_init, but after time init
     call t_startf('cldera_init')
-    call cldera_init("elm",mpicom_lnd,start_ymd,start_tod,curr_ymd,curr_tod,stop_ymd,stop_tod)
+    ! GH TODO: using ref_ymd and ref_tod here... is that right?
+    call cldera_init("elm",mpicom_lnd,start_ymd,start_tod,ref_ymd,ref_tod,stop_ymd,stop_tod)
     call cldera_set_log_unit (iulog)
     call cldera_set_masterproc (masterproc)
     call t_stopf('cldera_init')
@@ -348,6 +349,9 @@ contains
   !====================================================================================
 
   subroutine lnd_run_mct(EClock, cdata_l, x2l_l, l2x_l)
+#if defined(CLDERA_PROFILING)
+    use cldera_interface_mod , only: cldera_switch_context
+#endif
     !
     ! !DESCRIPTION:
     ! Run elm model
@@ -571,7 +575,8 @@ contains
 
   subroutine lnd_final_mct( EClock, cdata_l, x2l_l, l2x_l)
 #if defined(CLDERA_PROFILING)
-    use cldera_interface_mod, only: cldera_clean_up
+    use cldera_interface_mod, only: cldera_clean_up, cldera_switch_context
+    use perf_mod            , only: t_startf, t_stopf
 #endif
 
     !

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -234,10 +234,10 @@ contains
        call endrun( sub//' ERROR: unknown starttype' )
     end if
 
-#if false && defined(CLDERA_PROFILING)
+#if defined(CLDERA_PROFILING)
     ! Initialize CLDERA profiling before elm_init, but after time init
     call t_startf('cldera_init')
-    call cldera_init(mpicom_lnd,start_ymd,start_tod,curr_ymd,curr_tod,stop_ymd,stop_tod)
+    call cldera_init("elm",mpicom_lnd,start_ymd,start_tod,curr_ymd,curr_tod,stop_ymd,stop_tod)
     call cldera_set_log_unit (iulog)
     call cldera_set_masterproc (masterproc)
     call t_stopf('cldera_init')
@@ -472,6 +472,10 @@ contains
     call seq_infodata_GetData( infodata, orb_eccen=eccen, orb_mvelpp=mvelpp, &
          orb_lambm0=lambm0, orb_obliqr=obliqr )
 
+#if defined(CLDERA_PROFILING)
+    call cldera_switch_context("elm")
+#endif
+
     ! Loop over time steps in coupling interval
 
     dosend = .false.
@@ -591,8 +595,9 @@ contains
     ! fill this in
     call final()
 
-#if false && defined(CLDERA_PROFILING)
+#if defined(CLDERA_PROFILING)
     call t_startf('cldera_clean_up')
+    call cldera_switch_context("elm")
     call cldera_clean_up ()
     call t_stopf('cldera_clean_up')
 #endif

--- a/components/elm/src/main/histFileMod.F90
+++ b/components/elm/src/main/histFileMod.F90
@@ -33,6 +33,11 @@ module histFileMod
   use PRTGenericMod          , only : nelements_fates  => num_elements
   use TopounitType      , only : top_pp
   use topounit_varcon   , only: max_topounits, has_topounit
+#if defined(CLDERA_PROFILING)
+  use clm_time_manager     , only : get_curr_date
+  use perf_mod             , only : t_startf, t_stopf
+  use cldera_interface_mod , only : cldera_compute_stats
+#endif
 
   !
   implicit none
@@ -2786,6 +2791,9 @@ contains
     real(r8), pointer :: hist1do(:)      ! temporary
     character(len=*),parameter :: subname = 'hfields_write'
 !-----------------------------------------------------------------------
+#if defined(CLDERA_PROFILING)
+    integer :: ymd, yr, mon, day, tod
+#endif
 
     ! Write/define 1d topological info
 
@@ -2870,6 +2878,14 @@ contains
           endif
 
        else if (mode == 'write') then
+
+#if false && defined(CLDERA_PROFILING)
+          call get_curr_date( yr, mon, day, tod )
+          ymd = yr*10000 + mon*100 + day
+          call t_startf('cldera_elm_compute_stats')
+          call cldera_compute_stats(ymd,tod)
+          call t_stopf('cldera_elm_compute_stats')
+#endif
 
           ! Determine output buffer
 

--- a/components/elm/src/main/histFileMod.F90
+++ b/components/elm/src/main/histFileMod.F90
@@ -2879,15 +2879,6 @@ contains
 
        else if (mode == 'write') then
 
-#if false && defined(CLDERA_PROFILING)
-          call get_curr_date( yr, mon, day, tod )
-          ymd = yr*10000 + mon*100 + day
-          call t_startf('cldera_elm_compute_stats')
-          call cldera_switch_context("elm")
-          call cldera_compute_stats(ymd,tod)
-          call t_stopf('cldera_elm_compute_stats')
-#endif
-
           ! Determine output buffer
 
           histo => tape(t)%hlist(f)%hbuf

--- a/components/elm/src/main/histFileMod.F90
+++ b/components/elm/src/main/histFileMod.F90
@@ -36,7 +36,7 @@ module histFileMod
 #if defined(CLDERA_PROFILING)
   use clm_time_manager     , only : get_curr_date
   use perf_mod             , only : t_startf, t_stopf
-  use cldera_interface_mod , only : cldera_compute_stats
+  use cldera_interface_mod , only : cldera_compute_stats, cldera_switch_context
 #endif
 
   !
@@ -2883,6 +2883,7 @@ contains
           call get_curr_date( yr, mon, day, tod )
           ymd = yr*10000 + mon*100 + day
           call t_startf('cldera_elm_compute_stats')
+          call cldera_switch_context("elm")
           call cldera_compute_stats(ymd,tod)
           call t_stopf('cldera_elm_compute_stats')
 #endif


### PR DESCRIPTION
@jewatkins @bartgol 

I've verified that fully coupled runs with EAM and ELM both enabled via CLDERA-tools seem to run fine, but haven't checked the validity of the ELM data yet.
```
-rw-rw-r-- 1 gbharpe gbharpe    3684992 May 11 09:18 cldera_stats_eam-1991-06-01-00000.nc
-rw-rw-r-- 1 gbharpe gbharpe    7671552 May 11 09:18 cldera_stats_elm-1991-06-01-00000.nc
```

There are still two remaining issues:
1. I did not grab the H2OSOI variable. That's because H2OSOI is the only variable from ELM which is 2D, but the vertical direction isn't pressure, it's soil depth. This is something that has been on the backburner because it's just slightly more complicated than everything else. I know E3SM-wise it's stored in `col_pp%h2osoi_vol` in `ColumnDataType.F90`, and I know the number of soil layers is stored in `clm_varpar%nlevgrnd`.
2. The column GIDs are slightly off. For unexplained reasons, the column GIDs are not initialized when I copy them to CLDERA-tools, despite the CLDERA-tools hooks being located after all of ELM's initialize routines (aptly named `initialize1`, `initialize2`, `initialize3`). Currently I set all column GIDs are set to 1 in line 396 of `lnd_comp_mct.F90`.

I'm happy to have somebody look at this and consider merging this now and we can revisit the column GIDs issue when I return, or happy to wait until we're sure the data looks right. But either way, this doesn't cause errors or crashes with the EAM part as far as I can tell.