### PR TITLE
Update kokkos submodule

### DIFF
--- a/cime_config/machines/cmake_macros/gnu.cmake
+++ b/cime_config/machines/cmake_macros/gnu.cmake
@@ -1,5 +1,5 @@
 string(APPEND CFLAGS " -mcmodel=medium")
-string(APPEND CXXFLAGS " -std=c++14")
+string(APPEND CXXFLAGS " -std=c++17")
 string(APPEND FFLAGS " -mcmodel=medium -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none")
 if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
    string(APPEND FFLAGS " -fallow-argument-mismatch")

--- a/components/homme/src/share/compose/cedr_util.hpp
+++ b/components/homme/src/share/compose/cedr_util.hpp
@@ -5,6 +5,7 @@
 #define INCLUDE_CEDR_UTIL_HPP
 
 #include <sstream>
+#include <iostream>
 
 #include "cedr_kokkos.hpp"
 #include "cedr_mpi.hpp"

--- a/components/homme/src/share/compose/compose_kokkos.hpp
+++ b/components/homme/src/share/compose/compose_kokkos.hpp
@@ -20,10 +20,6 @@ using Const = typename View::const_type;
 
 // GPU-friendly replacements for std::*.
 template <typename T> KOKKOS_INLINE_FUNCTION
-const T& min (const T& a, const T& b) { return a < b ? a : b; }
-template <typename T> KOKKOS_INLINE_FUNCTION
-const T& max (const T& a, const T& b) { return a > b ? a : b; }
-template <typename T> KOKKOS_INLINE_FUNCTION
 void swap (T& a, T& b) { const auto tmp = a; a = b; b = tmp; }
 
 template <typename Real> struct NumericTraits;

--- a/components/homme/src/share/compose/compose_slmm.cpp
+++ b/components/homme/src/share/compose/compose_slmm.cpp
@@ -276,8 +276,6 @@ extern "C" {
 // Interface for Homme, through compose_mod.F90.
 void kokkos_init () {
   amb::dev_init_threads();
-  Kokkos::InitArguments args;
-  args.disable_warnings = true;
   initialize_kokkos();
   // Test these initialize correctly.
   Kokkos::View<int> v("hi");

--- a/components/homme/src/share/compose/compose_slmm_siqk.cpp
+++ b/components/homme/src/share/compose/compose_slmm_siqk.cpp
@@ -75,7 +75,7 @@ public:
   }
 
   KOKKOS_INLINE_FUNCTION
-  void join (volatile value_type& dst, volatile value_type const& src) const {
+  void join (value_type& dst, value_type const& src) const {
     dst.max_nits = max(dst.max_nits, src.max_nits);
     dst.sum_nits += src.sum_nits;
     dst.nfails += src.nfails;


### PR DESCRIPTION
To be compatible with ekat update in cldera-tools, we have to update kokkos in cldera-e3sm. This requires also a handful of changes in the source/cmake code (nothing major).

I tested this branch with the (soon to be) new master cldera-tools, and it ran fine.